### PR TITLE
including Yahoo as a provider

### DIFF
--- a/data/EmailProviders.json
+++ b/data/EmailProviders.json
@@ -5,6 +5,11 @@
     "slug": "/gmail"
   },
   {
+    "id": "yahoo",
+    "name": "Yahoo",
+    "slug": "/yahoo"
+  },
+  {
     "id": "att",
     "name": "AT&T",
     "slug": "/att"


### PR DESCRIPTION
This should include all smtp bounce responses from the destination MTA *yahoodns.net, which includes other recipient domains like AOL, Verizon, Netscape, etc.