### PR TITLE
Add two 553 error messages from Verizon Media (Yahoo!)

### DIFF
--- a/data/codes/553.json
+++ b/data/codes/553.json
@@ -28,6 +28,26 @@
           "links": []
         }
       ]
+    },
+    {
+      "id": "verizon",
+      "name": "Verizon Media",
+      "responses": [
+        {
+          "status": "5.7.1",
+          "response": "host mta7.am0.yahoodns.net [66.196.118.36] SMTP error from remote mail server after MAIL FROM:<user@example.com> SIZE=2022: 553 5.7.1 [BL21] Connections will not be accepted from 192.0.2.1, because the ip is in Spamhaus's list; see http://postmaster.yahoo.com/550-bl23.html",
+          "severity": 2,
+          "description": "",
+          "links": ["http://postmaster.yahoo.com/550-bl23.html"]
+        },
+        {
+          "status": "5.7.1",
+          "response": "host mta7.am0.yahoodns.net [66.196.118.34] SMTP error from remote mail server after MAIL FROM:<user@example.com> SIZE=2022: 553 Mail from 192.0.2.2 not allowed - 5.7.1 [BL23] Connections not accepted from IP addresses on Spamhaus XBL; see http://postmaster.yahoo.com/errors/550-bl23.html [550]",
+          "severity": 2,
+          "description": "",
+          "links": ["http://postmaster.yahoo.com/550-bl23.html"]
+        }
+      ]
     }
   ],
   "spamFilters": [


### PR DESCRIPTION
Add the following error messages from Yahoo!:
- `553 5.7.1 [BL21] Connections will not be accepted from 192.0.2.1, because the ip is in Spamhaus's list;`
- `553 Mail from 192.0.2.2 not allowed - 5.7.1 [BL23] Connections not accepted from IP addresses on Spamhaus XBL;`