### PR TITLE
Update EmailProviders.json

### DIFF
--- a/data/EmailProviders.json
+++ b/data/EmailProviders.json
@@ -15,7 +15,7 @@
     "name": "Yahoo Inc",
     "slug": "/yahoo",
     "domains": ["yahoo.com", "aol.com", "verizon.net"],
-    "description": "Yahoo Inc is a division of the internet service provider Verizon Communications, headquartered in New York City. It's known for its freemail services AOL and Yahoo!. Yahoo Inc provides a detailed Postmaster page with contact options for investigating false-positive spam verdicts. Some senders may also qualify for their \"Email Marketing Data Feeds\" with detailed insight on performance in the inbox.",
+    "description": "Yahoo Inc is headquartered in New York City. It's known for its freemail services AOL and Yahoo. Yahoo Inc provides a detailed Postmaster page with contact options for investigating false-positive spam verdicts. Some senders may also qualify for their \"Email Marketing Data Feeds\" with detailed insight on performance in the inbox.",
     "links": [
       "https://postmaster.yahooinc.com/",
       "https://postmaster.yahooinc.com/email-deliverability-performance-feeds"


### PR DESCRIPTION
Updated the description for Yahoo. Yahoo is no longer part of Verizon and it's "Yahoo" -- not "Yahoo!"