### PR TITLE
Add Yahoo, Exchange Online, Google Workspace, and Apple codes from 90-day production data

### DIFF
--- a/data/codes/421.json
+++ b/data/codes/421.json
@@ -34,6 +34,56 @@
          "severity": 3,
          "description": "The message is missing DKIM or SPF alignment for DMARC. Make sure your messages are passing DMARC. This message started appearing on January 21st, 2024 ahead of Gmail's new 2024 sender requirements.",
          "links": ["https://support.google.com/a/answer/10032578"]
+        },
+        {
+          "status": "4.7.26",
+          "response": "smtp;421 4.7.26 This message does not have authentication information or fails to pass authentication checks (SPF or DKIM). To best protect our users from spam, the message has been blocked. Please visit https://support.google.com/mail/answer/81126 for more information. - gsmtp",
+          "severity": 2,
+          "description": "Gmail requires all bulk senders to pass SPF or DKIM email authentication. This temporary failure indicates the message lacks valid authentication. Set up SPF and DKIM for your sending domain and ensure messages pass at least one check.",
+          "links": [
+            "https://support.google.com/mail/answer/81126",
+            "https://senders.google.com/"
+          ]
+        },
+        {
+          "status": "4.7.27",
+          "response": "smtp;421 4.7.27 This message failed SPF authentication. Gmail requires all bulk senders to pass SPF authentication. Please visit https://support.google.com/mail/answer/81126 for more information. - gsmtp",
+          "severity": 2,
+          "description": "Gmail's February 2024 bulk sender enforcement requires all bulk senders to pass SPF authentication. Messages failing SPF are temporarily rejected. Ensure your sending IP is listed in the SPF record for your envelope sender domain.",
+          "links": [
+            "https://support.google.com/mail/answer/81126",
+            "https://senders.google.com/"
+          ]
+        },
+        {
+          "status": "4.7.29",
+          "response": "smtp;421 4.7.29 This message was sent without TLS. Gmail requires all bulk senders to use TLS to transmit email. Please visit https://support.google.com/mail/answer/81126 for more information. - gsmtp",
+          "severity": 2,
+          "description": "Gmail's February 2024 bulk sender requirements mandate TLS for all bulk email. Ensure your mail transfer agent is configured to use STARTTLS when connecting to Gmail's MX servers.",
+          "links": [
+            "https://support.google.com/mail/answer/81126",
+            "https://senders.google.com/"
+          ]
+        },
+        {
+          "status": "4.7.30",
+          "response": "smtp;421 4.7.30 This message failed DKIM authentication. Gmail requires all bulk senders to sign their messages with DKIM. Please visit https://support.google.com/mail/answer/81126 for more information. - gsmtp",
+          "severity": 2,
+          "description": "Gmail's February 2024 bulk sender enforcement requires DKIM signing. Messages without a valid DKIM signature are temporarily rejected. Ensure your sending domain has a DKIM key published in DNS and that messages are signed.",
+          "links": [
+            "https://support.google.com/mail/answer/81126",
+            "https://senders.google.com/"
+          ]
+        },
+        {
+          "status": "4.7.40",
+          "response": "smtp;421 4.7.40 This message's envelope sender domain has no DMARC policy. Gmail requires all bulk senders to have a DMARC policy. Please visit https://support.google.com/mail/answer/81126 for more information. - gsmtp",
+          "severity": 2,
+          "description": "Gmail's February 2024 bulk sender requirements mandate a DMARC policy for the envelope sender domain. Publish a DMARC record (even p=none is acceptable to start) for your sending domain.",
+          "links": [
+            "https://support.google.com/mail/answer/81126",
+            "https://senders.google.com/"
+          ]
         }
       ]
     },

--- a/data/codes/451.json
+++ b/data/codes/451.json
@@ -12,7 +12,9 @@
           "response": "smtp;451 4.3.0 Mail server temporarily rejected message. - gsmtp",
           "severity": 0,
           "description": "",
-          "links": ["https://support.google.com/mail/answer/81126"]
+          "links": [
+            "https://support.google.com/mail/answer/81126"
+          ]
         }
       ]
     },
@@ -25,14 +27,29 @@
           "response": "smtp;451 example.yahoo.com Resources temporarily unavailable. Please try again later [#4.16.1].",
           "severity": 1,
           "description": "The sender's domain is currently unable to accept this message. Sending email in the future will most likely be successful.",
-          "links": ["https://postmaster.yahooinc.com/","https://postmaster.yahooinc.com/error-codes"]
+          "links": [
+            "https://postmaster.yahooinc.com/",
+            "https://postmaster.yahooinc.com/error-codes"
+          ]
         },
         {
           "status": "4.0.0-2",
           "response": "smtp;451 4.3.2 Internal server error",
           "severity": 0,
           "description": "",
-          "links": ["https://postmaster.yahooinc.com/","https://postmaster.yahooinc.com/error-codes"]
+          "links": [
+            "https://postmaster.yahooinc.com/",
+            "https://postmaster.yahooinc.com/error-codes"
+          ]
+        },
+        {
+          "status": "4.0.0-3",
+          "response": "smtp;451 Message temporarily deferred due to unresolvable RFC.5321 from domain. See https://senders.yahooinc.com/error-codes#unresolvable-from-domain",
+          "severity": 1,
+          "description": "Yahoo has temporarily rejected the message because the envelope FROM domain (RFC 5321) cannot be resolved in DNS. Ensure the sending domain has valid MX or A records and that your MAIL FROM domain is correctly configured.",
+          "links": [
+            "https://senders.yahooinc.com/error-codes#unresolvable-from-domain"
+          ]
         }
       ]
     },
@@ -99,7 +116,9 @@
           "response": "smtp;451 4.7.1 Service unavailable - try again later",
           "severity": 1,
           "description": "Messages are not being accepted right now. You may usually see this for sends happening at the \"top of the hour\" when many senders around the world are also sending aggressively to Apple.",
-          "links": ["https://support.apple.com/en-us/HT204137"]
+          "links": [
+            "https://support.apple.com/en-us/HT204137"
+          ]
         }
       ]
     },

--- a/data/codes/451.json
+++ b/data/codes/451.json
@@ -12,9 +12,7 @@
           "response": "smtp;451 4.3.0 Mail server temporarily rejected message. - gsmtp",
           "severity": 0,
           "description": "",
-          "links": [
-            "https://support.google.com/mail/answer/81126"
-          ]
+          "links": ["https://support.google.com/mail/answer/81126"]
         }
       ]
     },
@@ -27,29 +25,21 @@
           "response": "smtp;451 example.yahoo.com Resources temporarily unavailable. Please try again later [#4.16.1].",
           "severity": 1,
           "description": "The sender's domain is currently unable to accept this message. Sending email in the future will most likely be successful.",
-          "links": [
-            "https://postmaster.yahooinc.com/",
-            "https://postmaster.yahooinc.com/error-codes"
-          ]
+          "links": ["https://postmaster.yahooinc.com/","https://postmaster.yahooinc.com/error-codes"]
         },
         {
           "status": "4.0.0-2",
           "response": "smtp;451 4.3.2 Internal server error",
           "severity": 0,
           "description": "",
-          "links": [
-            "https://postmaster.yahooinc.com/",
-            "https://postmaster.yahooinc.com/error-codes"
-          ]
+          "links": ["https://postmaster.yahooinc.com/","https://postmaster.yahooinc.com/error-codes"]
         },
         {
           "status": "4.0.0-3",
           "response": "smtp;451 Message temporarily deferred due to unresolvable RFC.5321 from domain. See https://senders.yahooinc.com/error-codes#unresolvable-from-domain",
           "severity": 1,
-          "description": "Yahoo has temporarily rejected the message because the envelope FROM domain (RFC 5321) cannot be resolved in DNS. Ensure the sending domain has valid MX or A records and that your MAIL FROM domain is correctly configured.",
-          "links": [
-            "https://senders.yahooinc.com/error-codes#unresolvable-from-domain"
-          ]
+          "description": "Yahoo is temporarily deferring the message because the envelope sender (MAIL FROM) domain cannot be resolved in DNS. Ensure the envelope sender domain has valid MX and A records. The suffix '-3' is a schema key convention; the actual SMTP enhanced status code is 4.0.0.",
+          "links": ["https://senders.yahooinc.com/error-codes#unresolvable-from-domain"]
         }
       ]
     },
@@ -116,9 +106,7 @@
           "response": "smtp;451 4.7.1 Service unavailable - try again later",
           "severity": 1,
           "description": "Messages are not being accepted right now. You may usually see this for sends happening at the \"top of the hour\" when many senders around the world are also sending aggressively to Apple.",
-          "links": [
-            "https://support.apple.com/en-us/HT204137"
-          ]
+          "links": ["https://support.apple.com/en-us/HT204137"]
         }
       ]
     },

--- a/data/codes/550.json
+++ b/data/codes/550.json
@@ -1,7 +1,7 @@
 {
   "reply": 550,
   "slug": "/550",
-  "description": "The transaction failed permanently. The server will not try to send the message again. This is used as a general error code, so there are many reasons why you could be seeing it.<br><br>It’s common for email service providers to add a status code (5.1.1) after the SMTP reply code (smtp;550) for additional categorization of the issue.",
+  "description": "The transaction failed permanently. The server will not try to send the message again. This is used as a general error code, so there are many reasons why you could be seeing it.<br><br>It\u2019s common for email service providers to add a status code (5.1.1) after the SMTP reply code (smtp;550) for additional categorization of the issue.",
   "providers": [
     {
       "id": "google",
@@ -12,14 +12,18 @@
           "response": "smtp;550 5.1.1 The email account that you tried to reach does not exist. Please try double-checking the recipient's email address for typos or unnecessary spaces. Learn more at https://support.google.com/mail/?p=NoSuchUser - gsmtp",
           "severity": 0,
           "description": "",
-          "links": ["https://support.google.com/mail/answer/188131"]
+          "links": [
+            "https://support.google.com/mail/answer/188131"
+          ]
         },
         {
           "status": "5.2.1",
           "response": "smtp;550 5.2.1 The email account that you tried to reach is disabled. Learn more at https://support.google.com/mail/?p=DisabledUser - gsmtp",
           "severity": 0,
           "description": "",
-          "links": ["https://support.google.com/mail/answer/81126"]
+          "links": [
+            "https://support.google.com/mail/answer/81126"
+          ]
         },
         {
           "status": "5.2.1-2",
@@ -36,28 +40,45 @@
           "response": "smtp;550 5.7.1 [x.xx.xx.xx] Our system has detected that this message is likely suspicious due to the very low reputation of the sending domain. To best protect our users from spam, the message has been blocked. Please visit https://support.google.com/mail/answer/188131 for more information. - gsmtp",
           "severity": 4,
           "description": "Gmail has determined that the sending domain has a low reputation, so messages are now permanently rejected. See Google's documentation on how to determine the source of this poor reputation and how to improve deliverability.",
-          "links": ["https://support.google.com/mail/answer/81126"]
+          "links": [
+            "https://support.google.com/mail/answer/81126"
+          ]
         },
         {
           "status": "5.7.1-2",
           "response": "smtp;550 5.7.1 [x.xx.xx.xx] Our system has detected that this message is likely unsolicited mail. To reduce the amount of spam sent to Gmail, this message has been blocked. Please visit https://support.google.com/mail/?p=UnsolicitedMessageError for more information. - gsmtp",
           "severity": 4,
           "description": "Gmail has determined your messages are unsolicited, so messages are now permanently rejected. See Google's documentation for best practices to monitor and investigate this. ",
-          "links": ["https://support.google.com/mail/?p=UnsolicitedRateLimitError"]
+          "links": [
+            "https://support.google.com/mail/?p=UnsolicitedRateLimitError"
+          ]
         },
         {
           "status": "5.7.1-3",
           "response": "smtp;550 5.7.1 Unauthenticated email from example.com is not accepted due to domain's DMARC policy. Please contact the administrator of example.com domain if this was a legitimate mail. Please visit https://support.google.com/mail/answer/2451690 to learn about the DMARC initiative. - gsmtp",
           "severity": 3,
           "description": "The sent message failed the DMARC policy for the sending domain. If the sending domain has a reject policy set for DMARC, the message must pass DKIM or have SPF aligned to the domain with a custom Return-Path. To resolve this, you'll need to contact your email service provider to see how to send a message that passes DMARC support.",
-          "links": ["https://support.google.com/mail/answer/81126"]
+          "links": [
+            "https://support.google.com/mail/answer/81126"
+          ]
         },
         {
           "status": "5.7.1-4",
           "response": "smtp;550 5.7.1 [x.xx.xx.xx 14] Messages missing a valid address in From: header, or having no From: header, are not accepted. - gsmtp",
           "severity": 0,
           "description": "In most cases this is the result of a malformatted From name or email address.",
-          "links": ["https://tools.ietf.org/html/rfc2822#appendix-A.6"]
+          "links": [
+            "https://tools.ietf.org/html/rfc2822#appendix-A.6"
+          ]
+        },
+        {
+          "status": "5.7.1-5",
+          "response": "smtp;550 5.7.1 The user or domain that you are sending to (or from) has a policy that prohibited the mail that you sent. Please contact your domain administrator for further details. For more information, go to https://support.google.com/a/answer/172179",
+          "severity": 2,
+          "description": "The recipient's Google Workspace administrator has configured a policy that is blocking this message. This is a domain-wide or per-user restriction enforced by the receiving organization's Google Workspace admin \u2014 not a reputation issue with the sender.",
+          "links": [
+            "https://support.google.com/a/answer/172179"
+          ]
         }
       ]
     },
@@ -70,7 +91,10 @@
           "response": "smtp;550 relaying denied for <example@example.com>",
           "severity": 0,
           "description": "",
-          "links": ["https://postmaster.yahooinc.com/","https://postmaster.yahooinc.com/error-codes"]
+          "links": [
+            "https://postmaster.yahooinc.com/",
+            "https://postmaster.yahooinc.com/error-codes"
+          ]
         }
       ]
     },
@@ -83,28 +107,36 @@
           "response": "smtp;550 5.1.1 <example@icloud.com>: user does not exist",
           "severity": 0,
           "description": "This mailbox does not exist at Apple. Check to make sure there are no typos with the address.",
-          "links": ["https://support.apple.com/en-us/HT204137"]
+          "links": [
+            "https://support.apple.com/en-us/HT204137"
+          ]
         },
         {
           "status": "5.7.1",
           "response": "smtp;550 5.7.1 [CS01] Message rejected due to local policy. Please visit https://support.apple.com/en-us/HT204137",
           "severity": 0,
           "description": "Apple Mail is blocking the email because of an email filter policy on their end. If you're unsure of the source of this issue, and following Apple's suggested best practices, you can contact Apple's postmaster team with mail logs for delivery support. ",
-          "links": ["https://support.apple.com/en-us/HT204137"]
+          "links": [
+            "https://support.apple.com/en-us/HT204137"
+          ]
         },
         {
           "status": "5.7.1-2",
-          "response": "smtp;550 5.7.1 Your message was rejected due to example.com’s DMARC policy. See https://support.apple.com/en-us/HT204137 for info",
+          "response": "smtp;550 5.7.1 Your message was rejected due to example.com\u2019s DMARC policy. See https://support.apple.com/en-us/HT204137 for info",
           "severity": 3,
           "description": "The sent message failed the DMARC policy for the sending domain. If the sending domain has a reject policy set for DMARC, the message must pass DKIM or have SPF aligned to the domain with a custom Return-Path. To resolve this, you'll need to contact your email service provider to see how to send a message that passes DMARC support. ",
-          "links": ["https://support.apple.com/en-us/HT204137"]
+          "links": [
+            "https://support.apple.com/en-us/HT204137"
+          ]
         },
         {
           "status": "5.7.1-3",
           "response": "smtp;550 5.7.1 Your email was rejected due to having a domain present in the Spamhaus DBL -- see https://www.spamhaus.org/dbl/",
           "severity": 4,
           "description": "Apple Mail checks all URLs in your message content against the public block list Spamhaus. Spamhaus is a very reputable block list with few false-positive listings. You must cooperate with Spamhaus volunteers to resolve the listing. Remember that even once the listing is removed, it may take receivers up to 24 hours to refresh their cache and to see delivery resume. ",
-          "links": ["https://www.spamhaus.org/lookup/"]
+          "links": [
+            "https://www.spamhaus.org/lookup/"
+          ]
         }
       ]
     },
@@ -117,14 +149,18 @@
           "response": "smtp;550 5.1.1 Not our Customer",
           "severity": 1,
           "description": "This mailbox does not exist at Comcast. Check to make sure there are no typos with the address.",
-          "links": ["http://postmaster.comcast.net/"]
+          "links": [
+            "http://postmaster.comcast.net/"
+          ]
         },
         {
           "status": "5.1.1-2",
           "response": "smtp;550 5.1.1 <example@comcast.net> recipient mailbox unallocated",
           "severity": 0,
           "description": "",
-          "links": ["http://postmaster.comcast.net/"]
+          "links": [
+            "http://postmaster.comcast.net/"
+          ]
         },
         {
           "status": "5.2.0",
@@ -138,7 +174,9 @@
           "response": "smtp;550 5.2.0 <example@comcast.net> - Recipient unavailable",
           "severity": 0,
           "description": "",
-          "links": ["http://postmaster.comcast.net/"]
+          "links": [
+            "http://postmaster.comcast.net/"
+          ]
         }
       ]
     },
@@ -158,14 +196,18 @@
           "response": "smtp;550 5.7.1 Service unavailable, MailFrom domain is listed in Spamhaus. To request removal from this list see https://www.spamhaus.org/query/lookup/ (S8002) [#.eop-nam02.prod.protection.outlook.com]",
           "severity": 4,
           "description": "The MailFrom domain is also known as the Return-Path header domain, and is used to validate SPF authentication (it's not always the same domain as your From address for the message). Outlook checks your MailFrom domain against the public block list Spamhaus. Spamhaus is a very reputable block list with few false-positive listings. You must cooperate with Spamhaus volunteers to resolve the listing. Remember that even once the listing is removed, it may take receivers up to 24 hours to refresh their cache and to see delivery resume.",
-          "links": ["https://www.spamhaus.org/lookup/"]
+          "links": [
+            "https://www.spamhaus.org/lookup/"
+          ]
         },
         {
           "status": "5.7.1-2",
           "response": "smtp;550 5.7.1 Unfortunately, messages from [x.xx.xx.xx] weren't sent. Please contact your Internet service provider since part of their network is on our block list (S3150). You can also refer your provider to http://mail.live.com/mail/troubleshooting.aspx#errors. [#.eop-nam02.prod.protection.outlook.com]",
           "severity": 3,
           "description": "This is Microsoft's way of throttling your sending IP, possibly related to IP reputation classification. It should automatically expire on its own and is generally caused by sending too much traffic too fast.",
-          "links": ["https://sendersupport.olc.protection.outlook.com/pm/troubleshooting.aspx"]
+          "links": [
+            "https://sendersupport.olc.protection.outlook.com/pm/troubleshooting.aspx"
+          ]
         },
         {
           "status": "5.4.1",
@@ -225,7 +267,9 @@
           "response": "smtp;550 5.7.1 No such user!",
           "severity": 0,
           "description": "The email was sent to a non-existing address.",
-          "links": ["https://yandex.com/support/mail/bounces/yandex.html"]
+          "links": [
+            "https://yandex.com/support/mail/bounces/yandex.html"
+          ]
         }
       ]
     },
@@ -238,21 +282,27 @@
           "response": "smtp;550 5.2.1 <EXAMPLE@PRODIGY.NET>... Addressee unknown, relay=[x.xx.xx.xx]",
           "severity": 0,
           "description": "",
-          "links": ["https://www.att.com/support/article/email-support/KM1401980/"]
+          "links": [
+            "https://www.att.com/support/article/email-support/KM1401980/"
+          ]
         },
         {
           "status": "5.2.1-2",
           "response": "smtp;550 5.2.1 <example@prodigy.net>... blank mailhost - invalid address, relay=[x.xx.xx.xx]",
           "severity": 0,
           "description": "",
-          "links": ["https://www.att.com/support/article/email-support/KM1401980/"]
+          "links": [
+            "https://www.att.com/support/article/email-support/KM1401980/"
+          ]
         },
         {
           "status": "5.7.1",
           "response": "smtp;550 5.7.1 Connections not accepted from servers without a valid sender domain. ## Fix reverse DNS for x.xx.xx.xx",
           "severity": 3,
           "description": "Usually this is a reverse DNS (PTR) issue with the sending IP, but sometimes lookup failures by AT&T can cause this bounce to be a false-positive. After confirming reverse DNS is properly set up and the record has fully propagated, try resending the message. ",
-          "links": ["https://www.att.com/support/article/email-support/KM1401980/"]
+          "links": [
+            "https://www.att.com/support/article/email-support/KM1401980/"
+          ]
         }
       ]
     },
@@ -265,7 +315,9 @@
           "response": "smtp;550 5.7.1 Email rejected per DMARC policy for zoho.com",
           "severity": 0,
           "description": "This is related to using a zoho.com address from an external service or app without the Zoho SMTP settings in those apps.",
-          "links": ["https://help.zoho.com/portal/en/community/topic/preventing-spam-emails-using-zoho-com-enforcing-spf-dkim-and-dmarc-for-zoho-com-accounts"]
+          "links": [
+            "https://help.zoho.com/portal/en/community/topic/preventing-spam-emails-using-zoho-com-enforcing-spf-dkim-and-dmarc-for-zoho-com-accounts"
+          ]
         },
         {
           "status": "5.1.1",
@@ -285,28 +337,36 @@
           "response": "smtp;550 spam detected",
           "severity": 2,
           "description": "Free.fr determined the message that you sent included spam content. Check your mail to make sure it should not be missdetected as a spam, either by using an antispam softwate or by checking if the mail is syntaxically correct.",
-          "links": ["https://postmaster.free.fr/index_en.html"]
+          "links": [
+            "https://postmaster.free.fr/index_en.html"
+          ]
         },
         {
           "status": "5.2.2",
           "response": "smtp;550 5.2.2 user quota exceeded",
           "severity": 0,
           "description": "",
-          "links": ["https://postmaster.free.fr/index_en.html"]
+          "links": [
+            "https://postmaster.free.fr/index_en.html"
+          ]
         },
         {
           "status": "5.2.1",
           "response": "smtp;550 5.2.1 This mailbox has been blocked due to inactivity",
           "severity": 1,
           "description": "The mailbox is not currently active because of inactivity from the recipient. Once the recipient reactivates their mailbox, they'll be able to receive messages again.",
-          "links": ["https://postmaster.free.fr/index_en.html"]
+          "links": [
+            "https://postmaster.free.fr/index_en.html"
+          ]
         },
         {
           "status": "2",
           "response": "smtp;550 virus detected",
           "severity": 4,
           "description": "Free.fr has detected a virus in the message that you sent. Check your mail to make sure it should not be missdetected as a spam, either by using an antispam softwate or by checking if the mail is syntaxically correct.",
-          "links": ["https://postmaster.free.fr/index_en.html"]
+          "links": [
+            "https://postmaster.free.fr/index_en.html"
+          ]
         }
       ]
     },
@@ -319,14 +379,18 @@
           "response": "smtp;550 Requested action not taken: mailbox unavailable",
           "severity": 0,
           "description": "The specified recipient does not exist on their systems or the recipient has not used their inbox for an extended period of time and the inbox has been temporarily disabled due to inactivity. Please check the spelling of the email address.",
-          "links": ["https://postmaster.gmx.net/en/error-messages"]
+          "links": [
+            "https://postmaster.gmx.net/en/error-messages"
+          ]
         },
         {
           "status": "2",
           "response": "Requested action not taken: mailbox unavailable Reject due to policy restrictions.",
           "severity": 0,
           "description": "The message is being rejected due to policy reasons. This is likely down to the sender or IP being a spam source, or technical information included in the email doesn't meet some RFC standards.",
-          "links": ["https://www.gmx.net/mail/senderguidelines/"]
+          "links": [
+            "https://www.gmx.net/mail/senderguidelines/"
+          ]
         }
       ]
     },
@@ -339,7 +403,9 @@
           "response": "smtp;550 5.1.1 Email address could not be found, or was misspelled (G8)",
           "severity": 0,
           "description": "Recipient address does not exist on our system",
-          "links": ["https://postmaster.apps.rackspace.com/system-info/response-codes"]
+          "links": [
+            "https://postmaster.apps.rackspace.com/system-info/response-codes"
+          ]
         }
       ]
     },
@@ -378,49 +444,63 @@
           "response": "smtp;550 Mail is rejected by recipients ",
           "severity": 0,
           "description": "You are on this recipient's personal blacklist or your message has been rejected because of a filter they've created.",
-          "links": ["https://service.exmail.qq.com/cgi-bin/help?id=20022&no=1001262&subtype=1"]
+          "links": [
+            "https://service.exmail.qq.com/cgi-bin/help?id=20022&no=1001262&subtype=1"
+          ]
         },
         {
           "status": "2",
           "response": "smtp;550 Mailbox unavailable or access denied",
           "severity": 0,
           "description": "The recipient you're trying to send to is receiving a large number of emails in a short period of time. To avoid malicious attacks, sending to this recipient is temporarily prohibited.",
-          "links": ["https://service.exmail.qq.com/cgi-bin/help?subtype=1&id=20022&no=1000742"]
+          "links": [
+            "https://service.exmail.qq.com/cgi-bin/help?subtype=1&id=20022&no=1000742"
+          ]
         },
         {
           "status": "3",
           "response": "smtp;550 Mailbox not found. http://service.exmail.qq.com/cgi-bin/help?subtype=1&&id=20022&&no=1000728",
           "severity": 0,
           "description": "This recipient does not exist.",
-          "links": ["https://service.exmail.qq.com/cgi-bin/help?subtype=1&&id=20022&&no=1000728"]
+          "links": [
+            "https://service.exmail.qq.com/cgi-bin/help?subtype=1&&id=20022&&no=1000728"
+          ]
         },
         {
           "status": "4",
           "response": "smtp;550 Mail content denied. http://service.exmail.qq.com/cgi-bin/help?subtype=1&&id=20022&&no=1000726",
           "severity": 0,
           "description": "The content of the email was suspected of being sent in large numbers and was reported by a lot of users as spam.",
-          "links": ["http://service.exmail.qq.com/cgi-bin/help?subtype=1&&id=20022&&no=1000726"]
+          "links": [
+            "http://service.exmail.qq.com/cgi-bin/help?subtype=1&&id=20022&&no=1000726"
+          ]
         },
         {
           "status": "5",
           "response": "smtp;550 Sender frequency limited. http://service.exmail.qq.com/cgi-bin/help?subtype=1&&id=20022&&no=1000723",
           "severity": 0,
           "description": "The sender 's sending frequency exceeded the limit. The amount of time that further mail is prohibited from being delivered depends on the limit exceeded. (for example, sender, hourly, daily). These limits are not disclosed.",
-          "links": ["http://service.exmail.qq.com/cgi-bin/help?subtype=1&&id=20022&&no=1000723"]
+          "links": [
+            "http://service.exmail.qq.com/cgi-bin/help?subtype=1&&id=20022&&no=1000723"
+          ]
         },
         {
           "status": "6",
           "response": "smtp;550 Suspected spam sender.",
           "severity": 3,
           "description": "Suspected of spam/a large amount of spam was sent from the domain name or mail operator.",
-          "links": ["https://service.mail.qq.com/cgi-bin/help?subtype=1&&id=20022&&no=1001461"]
+          "links": [
+            "https://service.mail.qq.com/cgi-bin/help?subtype=1&&id=20022&&no=1001461"
+          ]
         },
         {
           "status": "7",
           "response": "smtp;550 DMARC check failed http://service.mail.qq.com/cgi-bin/help?subtype=1&&no=1001508&&id=16.",
           "severity": 3,
           "description": "The sent message failed the DMARC policy for the sending domain. If the sending domain has a reject policy set for DMARC, the message must pass DKIM or have SPF aligned to the domain with a custom Return-Path. To resolve this, you'll need to contact your email service provider to see how to send a message that passes DMARC support. ",
-          "links": ["http://service.mail.qq.com/cgi-bin/help?subtype=1&&no=1001508&&id=16"]
+          "links": [
+            "http://service.mail.qq.com/cgi-bin/help?subtype=1&&no=1001508&&id=16"
+          ]
         }
       ]
     },
@@ -486,7 +566,9 @@
           "response": "smtp;550 mwinfXXXX ME Adresse IP source bloquee pour incident de spam. Client host blocked for spamming issues. OFR006_102 Ref http://csi.cloudmark.com/reset-request/?ip=xxx.xxx.xxx.xxx [102]",
           "severity": 3,
           "description": "Your IP has been blocked by Cloudmark Sender Intelligence and must be delisted to deliver mail.",
-          "links": ["http://csi.cloudmark.com/reset-request"]
+          "links": [
+            "http://csi.cloudmark.com/reset-request"
+          ]
         }
       ]
     },
@@ -499,70 +581,90 @@
           "response": "smtp;550 <example@example.com>: Reject due to SPF policy. The originating IP of the message is not permitted by the domain owner",
           "severity": 0,
           "description": "The email was rejected, because it was sent from a server that is not included in the domain owner's SPF record. This usually indicates that the sender address has been spoofed and that the email is spam/phishing.",
-          "links": ["https://postmaster.web.de/en/error-messages"]
+          "links": [
+            "https://postmaster.web.de/en/error-messages"
+          ]
         },
         {
           "status": "2",
           "response": "smtp;550 <example@example.com>: Syntax error in parameters or arguments",
           "severity": 0,
           "description": "Due to an incorrect configuration, email reception has been refused. Please contact your administrator who should correct the server configuration based on their recommendations.",
-          "links": ["https://postmaster.web.de/en/best-practice"]
+          "links": [
+            "https://postmaster.web.de/en/best-practice"
+          ]
         },
         {
           "status": "3",
           "response": "smtp;550 <example@example.com>: Requested action not taken: mailbox unavailable",
           "severity": 0,
           "description": "The specified recipient does not exist on their systems or the recipient has not used their inbox for an extended period of time and the inbox has been temporarily disabled due to inactivity.",
-          "links": ["https://postmaster.web.de/en/error-messages"]
+          "links": [
+            "https://postmaster.web.de/en/error-messages"
+          ]
         },
         {
           "status": "4",
           "response": "smtp;550 <example@example.com>: Bad DNS PTR resource record",
           "severity": 0,
           "description": "Emails from your email server were rejected because the PTR Resource Record of your IP address does not follow their guidelines. Possible reasons for this can be: The PTR-RR states that the IP address was dynamically allocated or the PTR-RR is a generic standard entry of your provider. Please allocate an independent and fully qualified domain name to your email server.",
-          "links": ["https://postmaster.web.de/en/error-messages"]
+          "links": [
+            "https://postmaster.web.de/en/error-messages"
+          ]
         },
         {
           "status": "5",
           "response": "smtp;550 <example@example.com>: Reject due to policy restrictions (header based)",
           "severity": 0,
           "description": "Your message will be rejected by their system if: any of the technical information included in the email doesn't meet the standards, the email violates their guidelines or, it is not plausible, i.e.: when specifying the date. This is applicable to all emails with more than one of the following headers: BCC, CC, Date, From, Sender, Subject, To. In addition, the headers \"Date, From, Sender, To\" must be syntactically correct.",
-          "links": ["https://postmaster.web.de/en/email-policy"]
+          "links": [
+            "https://postmaster.web.de/en/email-policy"
+          ]
         },
         {
           "status": "6",
           "response": "smtp;550 <example@example.com>: Reject due to policy restrictions (domain based)",
           "severity": 0,
           "description": "The email has been rejected due to their current security policy. This may occur if the sender domain is known as a spam domain.",
-          "links": ["https://postmaster.web.de/en/email-policy"]
+          "links": [
+            "https://postmaster.web.de/en/email-policy"
+          ]
         },
         {
           "status": "7",
           "response": "smtp;550 <example@example.com>: Reject due to policy restrictions (IP based)",
           "severity": 0,
           "description": "If a high percentage of e-mails are classified as spam by their filters, all messages coming from the sender's IP address will be temporarily rejected for a specific time frame.",
-          "links": ["https://postmaster.web.de/en/email-policy"]
+          "links": [
+            "https://postmaster.web.de/en/email-policy"
+          ]
         },
         {
           "status": "8",
           "response": "smtp;550 <example@example.com>: Requested mail action aborted: exceeded storage allocation, Quota exceeded",
           "severity": 0,
           "description": "The potential recipient does not have sufficient free space in their inbox",
-          "links": ["https://postmaster.web.de/en/error-messages"]
+          "links": [
+            "https://postmaster.web.de/en/error-messages"
+          ]
         },
         {
           "status": "9",
           "response": "smtp;550 <example@example.com>: IP address is block listed",
           "severity": 0,
           "description": "Your IP is in one of the block lists used by Web.de",
-          "links": ["https://postmaster.web.de/en/error-messages"]
+          "links": [
+            "https://postmaster.web.de/en/error-messages"
+          ]
         },
         {
           "status": "10",
           "response": "smtp;550 <example@example.com>: Invalid DNS MX or A/AAAA resource record",
           "severity": 0,
           "description": "Your domain does not have an MX record or an A record that can receive replies or bounces, or the MX record is not resolvable.",
-          "links": ["https://postmaster.web.de/en/error-messages"]
+          "links": [
+            "https://postmaster.web.de/en/error-messages"
+          ]
         }
       ]
     }
@@ -584,7 +686,9 @@
           "response": "smtp;550 Rejected by header based Anti-Spoofing policy: email@example.com - https://community.mimecast.com/docs/DOC-1369#550 [#]",
           "severity": 0,
           "description": "Often this bounce is related to sending both 'To' and 'From' the same domain but through a third party (like an ESP).",
-          "links": ["https://community.mimecast.com/s/article/Configuring-Anti-Spoofing-Policies-1695615136"]
+          "links": [
+            "https://community.mimecast.com/s/article/Configuring-Anti-Spoofing-Policies-1695615136"
+          ]
         },
         {
           "status": "3",
@@ -598,14 +702,18 @@
           "response": "smtp;550 Envelope blocked - User Entry - https://community.mimecast.com/docs/DOC-1369#550 [#]",
           "severity": 0,
           "description": "This is not a global block for all Mimecast customers. Instead just this single recipient domain's administrator has blocked your mail.",
-          "links": ["https://community.mimecast.com/s/article/Mimecast-SMTP-Error-Codes-842605754"]
+          "links": [
+            "https://community.mimecast.com/s/article/Mimecast-SMTP-Error-Codes-842605754"
+          ]
         },
         {
           "status": "5",
           "response": "smtp;550 DMARC Sender Invalid - envelope rejected - https://community.mimecast.com/docs/DOC-1369#550 [#]",
           "severity": 3,
           "description": "The inbound message has been rejected because the sending IP address isn't listed in the published SPF records for the sending domain (Return-Path header domain). Ensure all the IP address for your mail servers are listed in your SPF records.",
-          "links": ["https://community.mimecast.com/s/article/Mimecast-SMTP-Error-Codes-842605754"]
+          "links": [
+            "https://community.mimecast.com/s/article/Mimecast-SMTP-Error-Codes-842605754"
+          ]
         }
       ]
     },
@@ -674,14 +782,18 @@
           "response": "smtp;550 5.7.1 <email@example.com>: Recipient address rejected: User email address is marked as invalid.",
           "severity": 0,
           "description": "",
-          "links": ["https://help.proofpoint.com/Proofpoint_Essentials/Email_Security/Administrator_Topics/110_logs/Common_Error_Codes_found_in_Message_Details"]
+          "links": [
+            "https://help.proofpoint.com/Proofpoint_Essentials/Email_Security/Administrator_Topics/110_logs/Common_Error_Codes_found_in_Message_Details"
+          ]
         },
         {
           "status": "5.7.1-2",
           "response": "smtp;550 5.7.1 Relaying denied",
           "severity": 0,
           "description": "Recipient is not a Proofpoint customer or you are not allowed to use Proofpoint as an SMTP relay.",
-          "links": ["https://help.proofpoint.com/Proofpoint_Essentials/Email_Security/Administrator_Topics/110_logs/Common_Error_Codes_found_in_Message_Details"]
+          "links": [
+            "https://help.proofpoint.com/Proofpoint_Essentials/Email_Security/Administrator_Topics/110_logs/Common_Error_Codes_found_in_Message_Details"
+          ]
         },
         {
           "status": "5.7.1-5",
@@ -695,14 +807,18 @@
           "response": "smtp;550 5.7.1 Service unavailable; client [x.xx.xx.xx] blocked using prs.proofpoint.com",
           "severity": 3,
           "description": "Your IP has been blocked by Proofpoint Dynamic Reputation and must be delisted to deliver mail.",
-          "links": ["https://ipcheck.proofpoint.com"]
+          "links": [
+            "https://ipcheck.proofpoint.com"
+          ]
         },
         {
           "status": "5.7.1-4",
           "response": "smtp;550 5.7.1 Service unavailable; client [x.xx.xx.xx] blocked using Cloudmark Sender Intelligence (Visit http://csi.cloudmark.com/reset-request/ if you feel this is in error)",
           "severity": 3,
           "description": "Your IP has been blocked by Cloudmark Sender Intelligence and must be delisted to deliver mail.",
-          "links": ["http://csi.cloudmark.com/reset-request/"]
+          "links": [
+            "http://csi.cloudmark.com/reset-request/"
+          ]
         }
       ]
     },
@@ -715,28 +831,97 @@
           "response": "smtp;550 5.4.1 [email@example.com]: Recipient address rejected: Access denied [example.com]",
           "severity": 0,
           "description": "Usually this bounce means the recipient address is invalid, but sometimes it can be caused by internal setup or routing issues. Reach out to the recipient's mail admin to verify.",
-          "links": ["https://support.microsoft.com/en-us/topic/ndr-error-code-550-5-4-1-recipient-address-rejected-access-denied-c0e98a8e-81db-49c2-9bf1-32a1734d3e77"]
+          "links": [
+            "https://support.microsoft.com/en-us/topic/ndr-error-code-550-5-4-1-recipient-address-rejected-access-denied-c0e98a8e-81db-49c2-9bf1-32a1734d3e77"
+          ]
         },
         {
           "status": "5.7.1",
           "response": "smtp;550 5.7.1 Service unavailable, Client host [x.xx.xx.xx] blocked using Spamhaus. To request removal from this list see https://www.spamhaus.org/query/ip/0.0.0.0 (AS16012611)",
           "severity": 4,
           "description": "Exchange Online checks the sending IP against the public block list Spamhaus. Spamhaus is a very reputable block list with few false-positive listings. You must cooperate with Spamhaus volunteers to resolve the listing. Remember that even once the listing is removed, it may take receivers up to 24 hours to refresh their cache and to see delivery resume.",
-          "links": ["https://www.spamhaus.org/lookup/"]
+          "links": [
+            "https://www.spamhaus.org/lookup/"
+          ]
         },
         {
           "status": "5.7.1-2",
           "response": "550 5.7.1 Service unavailable, Helo domain is listed in Spamhaus. To request removal from this list see https://www.spamhaus.org/query/lookup/ (S8001) [#.prod.protection.outlook.com]",
           "severity": 4,
           "description": "First, the forward DNS lookup (domain name to IP address) of your sending IP should match the HELO value set in your mailserver. Then Exchange Online checks this HELO domain against the public block list Spamhaus. Spamhaus is a very reputable block list with few false-positive listings. You must cooperate with Spamhaus volunteers to resolve the listing. Remember that even once the listing is removed, it may take receivers up to 24 hours to refresh their cache and to see delivery resume. ",
-          "links": ["https://www.spamhaus.org/lookup/"]
+          "links": [
+            "https://www.spamhaus.org/lookup/"
+          ]
         },
         {
           "status": "5.7.606",
           "response": "smtp;550 5.7.606 Access denied, banned sending IP [x.xx.xx.xx]. To request removal from this list please visit https://sender.office.com/ and follow the directions. For more information please go to  http://go.microsoft.com/fwlink/?LinkID=526655 (AS16012609)",
           "severity": 4,
           "description": "",
-          "links": ["https://sender.office.com/"]
+          "links": [
+            "https://sender.office.com/"
+          ]
+        },
+        {
+          "status": "5.7.1-3",
+          "response": "smtp;550 5.7.1 TRANSPORT.RULES.RejectMessage; the message was rejected by organization policy",
+          "severity": 2,
+          "description": "A Microsoft 365 / Exchange Online mail flow rule (transport rule) in the recipient organization is configured to reject this message. This is an admin-defined policy at the receiving end \u2014 there is typically nothing the sender can do except contact the recipient through another channel.",
+          "links": [
+            "https://learn.microsoft.com/en-us/exchange/security-and-compliance/mail-flow-rules/mail-flow-rules"
+          ]
+        },
+        {
+          "status": "5.7.133",
+          "response": "smtp;550 5.7.133 RESOLVER.RST.SenderNotAuthenticatedForGroup; authentication required; Delivery restriction check failed because the sender was not authenticated when sending to this group",
+          "severity": 2,
+          "description": "The recipient is a Microsoft 365 distribution group or mail-enabled security group configured to reject external or unauthenticated senders. Only members or explicitly approved senders can deliver to this group.",
+          "links": [
+            "https://learn.microsoft.com/en-us/microsoft-365/solutions/allow-members-to-send-as-or-send-on-behalf-of-group"
+          ]
+        },
+        {
+          "status": "5.7.520",
+          "response": "smtp;550 5.7.520 Access denied, Your organization does not allow external forwarding. Please contact your administrator for further assistance. AS(7555)",
+          "severity": 1,
+          "description": "The recipient's Microsoft 365 organization has disabled automatic external email forwarding (AS7555). Microsoft enforces this by default to prevent data exfiltration and spam relaying. The forwarding rule on the recipient's side is the cause \u2014 senders cannot work around this.",
+          "links": [
+            "https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/outbound-spam-policies-external-email-forwarding"
+          ]
+        },
+        {
+          "status": "5.7.129",
+          "response": "smtp;550 5.7.129 RESOLVER.RST.RestrictedToRecipientsPermission; not authorized to send to recipient because the sender isn't on the recipient's list of senders to accept mail from",
+          "severity": 1,
+          "description": "The recipient's Exchange Online mailbox is configured with a restricted sender list (safe senders / accepted senders only). Messages from addresses not on that list are rejected at delivery.",
+          "links": [
+            "https://learn.microsoft.com/en-us/exchange/mail-flow/mail-routing/recipient-resolution"
+          ]
+        },
+        {
+          "status": "5.7.134",
+          "response": "smtp;550 5.7.134 RESOLVER.RST.SenderNotAuthenticatedForMailbox; authentication required; Delivery restriction check failed because the sender was not authenticated when sending to this mailbox",
+          "severity": 2,
+          "description": "The recipient's Exchange Online mailbox requires authenticated senders. External unauthenticated senders are rejected. This is typically a per-mailbox restriction set by the organization's admin.",
+          "links": [
+            "https://learn.microsoft.com/en-us/exchange/mail-flow/mail-routing/recipient-resolution"
+          ]
+        },
+        {
+          "status": "5.1.10",
+          "response": "smtp;550 5.1.10 RESOLVER.ADR.RecipientNotFound; Recipient not found by SMTP address lookup",
+          "severity": 0,
+          "description": "The specified recipient address does not exist in the Microsoft 365 / Exchange Online directory. Remove this address from your sending list.",
+          "links": []
+        },
+        {
+          "status": "5.2.3",
+          "response": "smtp;550 5.2.3 RESOLVER.RST.RecipSizeLimit; message too large for this recipient",
+          "severity": 0,
+          "description": "The message exceeds the maximum size configured for this specific Exchange Online recipient. Reduce the message size or remove large attachments.",
+          "links": [
+            "https://learn.microsoft.com/en-us/exchange/mail-flow/message-size-limits"
+          ]
         }
       ]
     },
@@ -763,7 +948,9 @@
           "response": "smtp;550 Blocked",
           "severity": 0,
           "description": "Barracuda states that a 550 SMTP code means that the requested command failed because the user's mailbox was unavailable (for example, because it was not found, or because the command was rejected for policy reasons).",
-          "links": ["https://campus.barracuda.com/product/emailsecuritygateway/doc/39815000/smtp-error-codes/"]
+          "links": [
+            "https://campus.barracuda.com/product/emailsecuritygateway/doc/39815000/smtp-error-codes/"
+          ]
         },
         {
           "status": "4",
@@ -777,7 +964,9 @@
           "response": "smtp;550 permanent failure for one or more recipients (email@example.com:blocked)",
           "severity": 0,
           "description": "This specific message is being blocked for content or domain related reasons. It's not necessarily a permanent failure since a different message may deliver later.",
-          "links": ["https://campus.barracuda.com/product/emailsecuritygateway/knowledgebase/50160000000GWZ9AAO/My+emails+to+recipients+with+a+Barracuda+Spam+Firewall+keep+getting+blocked!+What+do+I+do/"]
+          "links": [
+            "https://campus.barracuda.com/product/emailsecuritygateway/knowledgebase/50160000000GWZ9AAO/My+emails+to+recipients+with+a+Barracuda+Spam+Firewall+keep+getting+blocked!+What+do+I+do/"
+          ]
         }
       ]
     },
@@ -803,7 +992,9 @@
           "response": "smtp;550 5.7.1 <example@example.com>: Recipient address rejected: ERS-Customized-Block.",
           "severity": 0,
           "description": "'ERS' stands for Trend Micro's 'Email Reputation System', which provides custom levels of threat protection including sensitivity preferences and custom filters.",
-          "links": ["https://success.trendmicro.com/solution/TP000087438-How-do-I-edit-Reputation-Settings"]
+          "links": [
+            "https://success.trendmicro.com/solution/TP000087438-How-do-I-edit-Reputation-Settings"
+          ]
         }
       ]
     },

--- a/data/codes/550.json
+++ b/data/codes/550.json
@@ -1,7 +1,7 @@
 {
   "reply": 550,
   "slug": "/550",
-  "description": "The transaction failed permanently. The server will not try to send the message again. This is used as a general error code, so there are many reasons why you could be seeing it.<br><br>It\u2019s common for email service providers to add a status code (5.1.1) after the SMTP reply code (smtp;550) for additional categorization of the issue.",
+  "description": "The transaction failed permanently. The server will not try to send the message again. This is used as a general error code, so there are many reasons why you could be seeing it.<br><br>It’s common for email service providers to add a status code (5.1.1) after the SMTP reply code (smtp;550) for additional categorization of the issue.",
   "providers": [
     {
       "id": "google",
@@ -12,18 +12,14 @@
           "response": "smtp;550 5.1.1 The email account that you tried to reach does not exist. Please try double-checking the recipient's email address for typos or unnecessary spaces. Learn more at https://support.google.com/mail/?p=NoSuchUser - gsmtp",
           "severity": 0,
           "description": "",
-          "links": [
-            "https://support.google.com/mail/answer/188131"
-          ]
+          "links": ["https://support.google.com/mail/answer/188131"]
         },
         {
           "status": "5.2.1",
           "response": "smtp;550 5.2.1 The email account that you tried to reach is disabled. Learn more at https://support.google.com/mail/?p=DisabledUser - gsmtp",
           "severity": 0,
           "description": "",
-          "links": [
-            "https://support.google.com/mail/answer/81126"
-          ]
+          "links": ["https://support.google.com/mail/answer/81126"]
         },
         {
           "status": "5.2.1-2",
@@ -40,44 +36,84 @@
           "response": "smtp;550 5.7.1 [x.xx.xx.xx] Our system has detected that this message is likely suspicious due to the very low reputation of the sending domain. To best protect our users from spam, the message has been blocked. Please visit https://support.google.com/mail/answer/188131 for more information. - gsmtp",
           "severity": 4,
           "description": "Gmail has determined that the sending domain has a low reputation, so messages are now permanently rejected. See Google's documentation on how to determine the source of this poor reputation and how to improve deliverability.",
-          "links": [
-            "https://support.google.com/mail/answer/81126"
-          ]
+          "links": ["https://support.google.com/mail/answer/81126"]
         },
         {
           "status": "5.7.1-2",
           "response": "smtp;550 5.7.1 [x.xx.xx.xx] Our system has detected that this message is likely unsolicited mail. To reduce the amount of spam sent to Gmail, this message has been blocked. Please visit https://support.google.com/mail/?p=UnsolicitedMessageError for more information. - gsmtp",
           "severity": 4,
           "description": "Gmail has determined your messages are unsolicited, so messages are now permanently rejected. See Google's documentation for best practices to monitor and investigate this. ",
-          "links": [
-            "https://support.google.com/mail/?p=UnsolicitedRateLimitError"
-          ]
+          "links": ["https://support.google.com/mail/?p=UnsolicitedRateLimitError"]
         },
         {
           "status": "5.7.1-3",
           "response": "smtp;550 5.7.1 Unauthenticated email from example.com is not accepted due to domain's DMARC policy. Please contact the administrator of example.com domain if this was a legitimate mail. Please visit https://support.google.com/mail/answer/2451690 to learn about the DMARC initiative. - gsmtp",
           "severity": 3,
           "description": "The sent message failed the DMARC policy for the sending domain. If the sending domain has a reject policy set for DMARC, the message must pass DKIM or have SPF aligned to the domain with a custom Return-Path. To resolve this, you'll need to contact your email service provider to see how to send a message that passes DMARC support.",
-          "links": [
-            "https://support.google.com/mail/answer/81126"
-          ]
+          "links": ["https://support.google.com/mail/answer/81126"]
         },
         {
           "status": "5.7.1-4",
           "response": "smtp;550 5.7.1 [x.xx.xx.xx 14] Messages missing a valid address in From: header, or having no From: header, are not accepted. - gsmtp",
           "severity": 0,
           "description": "In most cases this is the result of a malformatted From name or email address.",
-          "links": [
-            "https://tools.ietf.org/html/rfc2822#appendix-A.6"
-          ]
+          "links": ["https://tools.ietf.org/html/rfc2822#appendix-A.6"]
         },
         {
           "status": "5.7.1-5",
-          "response": "smtp;550 5.7.1 The user or domain that you are sending to (or from) has a policy that prohibited the mail that you sent. Please contact your domain administrator for further details. For more information, go to https://support.google.com/a/answer/172179",
+          "response": "smtp;550 5.7.1 This message is blocked because the sender has not set up Google Workspace email correctly. For instructions on setting up Google Workspace, visit https://support.google.com/a/answer/174126 - gsmtp",
           "severity": 2,
-          "description": "The recipient's Google Workspace administrator has configured a policy that is blocking this message. This is a domain-wide or per-user restriction enforced by the receiving organization's Google Workspace admin \u2014 not a reputation issue with the sender.",
+          "description": "A Google Workspace administrator has blocked outbound or relay email due to incorrect configuration. This affects senders whose domain is managed by Google Workspace. The domain admin must correct the Workspace email settings.",
+          "links": ["https://support.google.com/a/answer/174126"]
+        },
+        {
+          "status": "5.7.26",
+          "response": "smtp;550 5.7.26 This message does not have authentication information or fails to pass authentication checks (SPF or DKIM). To best protect our users from spam, the message has been blocked. Please visit https://support.google.com/mail/answer/81126 for more information. - gsmtp",
+          "severity": 3,
+          "description": "Gmail's February 2024 bulk sender enforcement permanently rejects messages that fail both SPF and DKIM authentication. Set up SPF and DKIM for your sending domain. At least one must pass and be aligned with the From domain for DMARC compliance.",
           "links": [
-            "https://support.google.com/a/answer/172179"
+            "https://support.google.com/mail/answer/81126",
+            "https://senders.google.com/"
+          ]
+        },
+        {
+          "status": "5.7.27",
+          "response": "smtp;550 5.7.27 This message failed SPF authentication. Gmail requires all bulk senders to pass SPF authentication. Please visit https://support.google.com/mail/answer/81126 for more information. - gsmtp",
+          "severity": 3,
+          "description": "Gmail's February 2024 bulk sender requirements permanently reject messages failing SPF. Ensure your sending IP is authorized in the SPF record for the envelope sender domain, and that the record does not exceed the 10-lookup limit.",
+          "links": [
+            "https://support.google.com/mail/answer/81126",
+            "https://senders.google.com/"
+          ]
+        },
+        {
+          "status": "5.7.29",
+          "response": "smtp;550 5.7.29 This message was sent without TLS. Gmail requires all bulk senders to use TLS to transmit email. Please visit https://support.google.com/mail/answer/81126 for more information. - gsmtp",
+          "severity": 3,
+          "description": "Gmail's February 2024 bulk sender requirements permanently reject messages sent without TLS. Ensure your mail transfer agent negotiates STARTTLS when connecting to Gmail's inbound MX servers.",
+          "links": [
+            "https://support.google.com/mail/answer/81126",
+            "https://senders.google.com/"
+          ]
+        },
+        {
+          "status": "5.7.30",
+          "response": "smtp;550 5.7.30 This message failed DKIM authentication. Gmail requires all bulk senders to sign their messages with DKIM. Please visit https://support.google.com/mail/answer/81126 for more information. - gsmtp",
+          "severity": 3,
+          "description": "Gmail's February 2024 bulk sender requirements permanently reject messages without a valid DKIM signature. Ensure your sending domain has a DKIM key published and that all outbound messages are signed with a key that aligns to the From domain.",
+          "links": [
+            "https://support.google.com/mail/answer/81126",
+            "https://senders.google.com/"
+          ]
+        },
+        {
+          "status": "5.7.40",
+          "response": "smtp;550 5.7.40 This message's envelope sender domain has no DMARC policy. Gmail requires all bulk senders to have a DMARC policy. Please visit https://support.google.com/mail/answer/81126 for more information. - gsmtp",
+          "severity": 3,
+          "description": "Gmail's February 2024 bulk sender requirements permanently reject messages from domains without a DMARC policy. Publish a DMARC TXT record in DNS for your sending domain. Starting with p=none is acceptable.",
+          "links": [
+            "https://support.google.com/mail/answer/81126",
+            "https://senders.google.com/"
           ]
         }
       ]
@@ -91,10 +127,7 @@
           "response": "smtp;550 relaying denied for <example@example.com>",
           "severity": 0,
           "description": "",
-          "links": [
-            "https://postmaster.yahooinc.com/",
-            "https://postmaster.yahooinc.com/error-codes"
-          ]
+          "links": ["https://postmaster.yahooinc.com/","https://postmaster.yahooinc.com/error-codes"]
         }
       ]
     },
@@ -107,36 +140,28 @@
           "response": "smtp;550 5.1.1 <example@icloud.com>: user does not exist",
           "severity": 0,
           "description": "This mailbox does not exist at Apple. Check to make sure there are no typos with the address.",
-          "links": [
-            "https://support.apple.com/en-us/HT204137"
-          ]
+          "links": ["https://support.apple.com/en-us/HT204137"]
         },
         {
           "status": "5.7.1",
           "response": "smtp;550 5.7.1 [CS01] Message rejected due to local policy. Please visit https://support.apple.com/en-us/HT204137",
           "severity": 0,
           "description": "Apple Mail is blocking the email because of an email filter policy on their end. If you're unsure of the source of this issue, and following Apple's suggested best practices, you can contact Apple's postmaster team with mail logs for delivery support. ",
-          "links": [
-            "https://support.apple.com/en-us/HT204137"
-          ]
+          "links": ["https://support.apple.com/en-us/HT204137"]
         },
         {
           "status": "5.7.1-2",
-          "response": "smtp;550 5.7.1 Your message was rejected due to example.com\u2019s DMARC policy. See https://support.apple.com/en-us/HT204137 for info",
+          "response": "smtp;550 5.7.1 Your message was rejected due to example.com’s DMARC policy. See https://support.apple.com/en-us/HT204137 for info",
           "severity": 3,
           "description": "The sent message failed the DMARC policy for the sending domain. If the sending domain has a reject policy set for DMARC, the message must pass DKIM or have SPF aligned to the domain with a custom Return-Path. To resolve this, you'll need to contact your email service provider to see how to send a message that passes DMARC support. ",
-          "links": [
-            "https://support.apple.com/en-us/HT204137"
-          ]
+          "links": ["https://support.apple.com/en-us/HT204137"]
         },
         {
           "status": "5.7.1-3",
           "response": "smtp;550 5.7.1 Your email was rejected due to having a domain present in the Spamhaus DBL -- see https://www.spamhaus.org/dbl/",
           "severity": 4,
           "description": "Apple Mail checks all URLs in your message content against the public block list Spamhaus. Spamhaus is a very reputable block list with few false-positive listings. You must cooperate with Spamhaus volunteers to resolve the listing. Remember that even once the listing is removed, it may take receivers up to 24 hours to refresh their cache and to see delivery resume. ",
-          "links": [
-            "https://www.spamhaus.org/lookup/"
-          ]
+          "links": ["https://www.spamhaus.org/lookup/"]
         }
       ]
     },
@@ -149,18 +174,14 @@
           "response": "smtp;550 5.1.1 Not our Customer",
           "severity": 1,
           "description": "This mailbox does not exist at Comcast. Check to make sure there are no typos with the address.",
-          "links": [
-            "http://postmaster.comcast.net/"
-          ]
+          "links": ["http://postmaster.comcast.net/"]
         },
         {
           "status": "5.1.1-2",
           "response": "smtp;550 5.1.1 <example@comcast.net> recipient mailbox unallocated",
           "severity": 0,
           "description": "",
-          "links": [
-            "http://postmaster.comcast.net/"
-          ]
+          "links": ["http://postmaster.comcast.net/"]
         },
         {
           "status": "5.2.0",
@@ -174,9 +195,7 @@
           "response": "smtp;550 5.2.0 <example@comcast.net> - Recipient unavailable",
           "severity": 0,
           "description": "",
-          "links": [
-            "http://postmaster.comcast.net/"
-          ]
+          "links": ["http://postmaster.comcast.net/"]
         }
       ]
     },
@@ -196,18 +215,14 @@
           "response": "smtp;550 5.7.1 Service unavailable, MailFrom domain is listed in Spamhaus. To request removal from this list see https://www.spamhaus.org/query/lookup/ (S8002) [#.eop-nam02.prod.protection.outlook.com]",
           "severity": 4,
           "description": "The MailFrom domain is also known as the Return-Path header domain, and is used to validate SPF authentication (it's not always the same domain as your From address for the message). Outlook checks your MailFrom domain against the public block list Spamhaus. Spamhaus is a very reputable block list with few false-positive listings. You must cooperate with Spamhaus volunteers to resolve the listing. Remember that even once the listing is removed, it may take receivers up to 24 hours to refresh their cache and to see delivery resume.",
-          "links": [
-            "https://www.spamhaus.org/lookup/"
-          ]
+          "links": ["https://www.spamhaus.org/lookup/"]
         },
         {
           "status": "5.7.1-2",
           "response": "smtp;550 5.7.1 Unfortunately, messages from [x.xx.xx.xx] weren't sent. Please contact your Internet service provider since part of their network is on our block list (S3150). You can also refer your provider to http://mail.live.com/mail/troubleshooting.aspx#errors. [#.eop-nam02.prod.protection.outlook.com]",
           "severity": 3,
           "description": "This is Microsoft's way of throttling your sending IP, possibly related to IP reputation classification. It should automatically expire on its own and is generally caused by sending too much traffic too fast.",
-          "links": [
-            "https://sendersupport.olc.protection.outlook.com/pm/troubleshooting.aspx"
-          ]
+          "links": ["https://sendersupport.olc.protection.outlook.com/pm/troubleshooting.aspx"]
         },
         {
           "status": "5.4.1",
@@ -267,9 +282,7 @@
           "response": "smtp;550 5.7.1 No such user!",
           "severity": 0,
           "description": "The email was sent to a non-existing address.",
-          "links": [
-            "https://yandex.com/support/mail/bounces/yandex.html"
-          ]
+          "links": ["https://yandex.com/support/mail/bounces/yandex.html"]
         }
       ]
     },
@@ -282,27 +295,21 @@
           "response": "smtp;550 5.2.1 <EXAMPLE@PRODIGY.NET>... Addressee unknown, relay=[x.xx.xx.xx]",
           "severity": 0,
           "description": "",
-          "links": [
-            "https://www.att.com/support/article/email-support/KM1401980/"
-          ]
+          "links": ["https://www.att.com/support/article/email-support/KM1401980/"]
         },
         {
           "status": "5.2.1-2",
           "response": "smtp;550 5.2.1 <example@prodigy.net>... blank mailhost - invalid address, relay=[x.xx.xx.xx]",
           "severity": 0,
           "description": "",
-          "links": [
-            "https://www.att.com/support/article/email-support/KM1401980/"
-          ]
+          "links": ["https://www.att.com/support/article/email-support/KM1401980/"]
         },
         {
           "status": "5.7.1",
           "response": "smtp;550 5.7.1 Connections not accepted from servers without a valid sender domain. ## Fix reverse DNS for x.xx.xx.xx",
           "severity": 3,
           "description": "Usually this is a reverse DNS (PTR) issue with the sending IP, but sometimes lookup failures by AT&T can cause this bounce to be a false-positive. After confirming reverse DNS is properly set up and the record has fully propagated, try resending the message. ",
-          "links": [
-            "https://www.att.com/support/article/email-support/KM1401980/"
-          ]
+          "links": ["https://www.att.com/support/article/email-support/KM1401980/"]
         }
       ]
     },
@@ -315,9 +322,7 @@
           "response": "smtp;550 5.7.1 Email rejected per DMARC policy for zoho.com",
           "severity": 0,
           "description": "This is related to using a zoho.com address from an external service or app without the Zoho SMTP settings in those apps.",
-          "links": [
-            "https://help.zoho.com/portal/en/community/topic/preventing-spam-emails-using-zoho-com-enforcing-spf-dkim-and-dmarc-for-zoho-com-accounts"
-          ]
+          "links": ["https://help.zoho.com/portal/en/community/topic/preventing-spam-emails-using-zoho-com-enforcing-spf-dkim-and-dmarc-for-zoho-com-accounts"]
         },
         {
           "status": "5.1.1",
@@ -337,36 +342,28 @@
           "response": "smtp;550 spam detected",
           "severity": 2,
           "description": "Free.fr determined the message that you sent included spam content. Check your mail to make sure it should not be missdetected as a spam, either by using an antispam softwate or by checking if the mail is syntaxically correct.",
-          "links": [
-            "https://postmaster.free.fr/index_en.html"
-          ]
+          "links": ["https://postmaster.free.fr/index_en.html"]
         },
         {
           "status": "5.2.2",
           "response": "smtp;550 5.2.2 user quota exceeded",
           "severity": 0,
           "description": "",
-          "links": [
-            "https://postmaster.free.fr/index_en.html"
-          ]
+          "links": ["https://postmaster.free.fr/index_en.html"]
         },
         {
           "status": "5.2.1",
           "response": "smtp;550 5.2.1 This mailbox has been blocked due to inactivity",
           "severity": 1,
           "description": "The mailbox is not currently active because of inactivity from the recipient. Once the recipient reactivates their mailbox, they'll be able to receive messages again.",
-          "links": [
-            "https://postmaster.free.fr/index_en.html"
-          ]
+          "links": ["https://postmaster.free.fr/index_en.html"]
         },
         {
           "status": "2",
           "response": "smtp;550 virus detected",
           "severity": 4,
           "description": "Free.fr has detected a virus in the message that you sent. Check your mail to make sure it should not be missdetected as a spam, either by using an antispam softwate or by checking if the mail is syntaxically correct.",
-          "links": [
-            "https://postmaster.free.fr/index_en.html"
-          ]
+          "links": ["https://postmaster.free.fr/index_en.html"]
         }
       ]
     },
@@ -379,18 +376,14 @@
           "response": "smtp;550 Requested action not taken: mailbox unavailable",
           "severity": 0,
           "description": "The specified recipient does not exist on their systems or the recipient has not used their inbox for an extended period of time and the inbox has been temporarily disabled due to inactivity. Please check the spelling of the email address.",
-          "links": [
-            "https://postmaster.gmx.net/en/error-messages"
-          ]
+          "links": ["https://postmaster.gmx.net/en/error-messages"]
         },
         {
           "status": "2",
           "response": "Requested action not taken: mailbox unavailable Reject due to policy restrictions.",
           "severity": 0,
           "description": "The message is being rejected due to policy reasons. This is likely down to the sender or IP being a spam source, or technical information included in the email doesn't meet some RFC standards.",
-          "links": [
-            "https://www.gmx.net/mail/senderguidelines/"
-          ]
+          "links": ["https://www.gmx.net/mail/senderguidelines/"]
         }
       ]
     },
@@ -403,9 +396,7 @@
           "response": "smtp;550 5.1.1 Email address could not be found, or was misspelled (G8)",
           "severity": 0,
           "description": "Recipient address does not exist on our system",
-          "links": [
-            "https://postmaster.apps.rackspace.com/system-info/response-codes"
-          ]
+          "links": ["https://postmaster.apps.rackspace.com/system-info/response-codes"]
         }
       ]
     },
@@ -444,63 +435,49 @@
           "response": "smtp;550 Mail is rejected by recipients ",
           "severity": 0,
           "description": "You are on this recipient's personal blacklist or your message has been rejected because of a filter they've created.",
-          "links": [
-            "https://service.exmail.qq.com/cgi-bin/help?id=20022&no=1001262&subtype=1"
-          ]
+          "links": ["https://service.exmail.qq.com/cgi-bin/help?id=20022&no=1001262&subtype=1"]
         },
         {
           "status": "2",
           "response": "smtp;550 Mailbox unavailable or access denied",
           "severity": 0,
           "description": "The recipient you're trying to send to is receiving a large number of emails in a short period of time. To avoid malicious attacks, sending to this recipient is temporarily prohibited.",
-          "links": [
-            "https://service.exmail.qq.com/cgi-bin/help?subtype=1&id=20022&no=1000742"
-          ]
+          "links": ["https://service.exmail.qq.com/cgi-bin/help?subtype=1&id=20022&no=1000742"]
         },
         {
           "status": "3",
           "response": "smtp;550 Mailbox not found. http://service.exmail.qq.com/cgi-bin/help?subtype=1&&id=20022&&no=1000728",
           "severity": 0,
           "description": "This recipient does not exist.",
-          "links": [
-            "https://service.exmail.qq.com/cgi-bin/help?subtype=1&&id=20022&&no=1000728"
-          ]
+          "links": ["https://service.exmail.qq.com/cgi-bin/help?subtype=1&&id=20022&&no=1000728"]
         },
         {
           "status": "4",
           "response": "smtp;550 Mail content denied. http://service.exmail.qq.com/cgi-bin/help?subtype=1&&id=20022&&no=1000726",
           "severity": 0,
           "description": "The content of the email was suspected of being sent in large numbers and was reported by a lot of users as spam.",
-          "links": [
-            "http://service.exmail.qq.com/cgi-bin/help?subtype=1&&id=20022&&no=1000726"
-          ]
+          "links": ["http://service.exmail.qq.com/cgi-bin/help?subtype=1&&id=20022&&no=1000726"]
         },
         {
           "status": "5",
           "response": "smtp;550 Sender frequency limited. http://service.exmail.qq.com/cgi-bin/help?subtype=1&&id=20022&&no=1000723",
           "severity": 0,
           "description": "The sender 's sending frequency exceeded the limit. The amount of time that further mail is prohibited from being delivered depends on the limit exceeded. (for example, sender, hourly, daily). These limits are not disclosed.",
-          "links": [
-            "http://service.exmail.qq.com/cgi-bin/help?subtype=1&&id=20022&&no=1000723"
-          ]
+          "links": ["http://service.exmail.qq.com/cgi-bin/help?subtype=1&&id=20022&&no=1000723"]
         },
         {
           "status": "6",
           "response": "smtp;550 Suspected spam sender.",
           "severity": 3,
           "description": "Suspected of spam/a large amount of spam was sent from the domain name or mail operator.",
-          "links": [
-            "https://service.mail.qq.com/cgi-bin/help?subtype=1&&id=20022&&no=1001461"
-          ]
+          "links": ["https://service.mail.qq.com/cgi-bin/help?subtype=1&&id=20022&&no=1001461"]
         },
         {
           "status": "7",
           "response": "smtp;550 DMARC check failed http://service.mail.qq.com/cgi-bin/help?subtype=1&&no=1001508&&id=16.",
           "severity": 3,
           "description": "The sent message failed the DMARC policy for the sending domain. If the sending domain has a reject policy set for DMARC, the message must pass DKIM or have SPF aligned to the domain with a custom Return-Path. To resolve this, you'll need to contact your email service provider to see how to send a message that passes DMARC support. ",
-          "links": [
-            "http://service.mail.qq.com/cgi-bin/help?subtype=1&&no=1001508&&id=16"
-          ]
+          "links": ["http://service.mail.qq.com/cgi-bin/help?subtype=1&&no=1001508&&id=16"]
         }
       ]
     },
@@ -566,9 +543,7 @@
           "response": "smtp;550 mwinfXXXX ME Adresse IP source bloquee pour incident de spam. Client host blocked for spamming issues. OFR006_102 Ref http://csi.cloudmark.com/reset-request/?ip=xxx.xxx.xxx.xxx [102]",
           "severity": 3,
           "description": "Your IP has been blocked by Cloudmark Sender Intelligence and must be delisted to deliver mail.",
-          "links": [
-            "http://csi.cloudmark.com/reset-request"
-          ]
+          "links": ["http://csi.cloudmark.com/reset-request"]
         }
       ]
     },
@@ -581,90 +556,70 @@
           "response": "smtp;550 <example@example.com>: Reject due to SPF policy. The originating IP of the message is not permitted by the domain owner",
           "severity": 0,
           "description": "The email was rejected, because it was sent from a server that is not included in the domain owner's SPF record. This usually indicates that the sender address has been spoofed and that the email is spam/phishing.",
-          "links": [
-            "https://postmaster.web.de/en/error-messages"
-          ]
+          "links": ["https://postmaster.web.de/en/error-messages"]
         },
         {
           "status": "2",
           "response": "smtp;550 <example@example.com>: Syntax error in parameters or arguments",
           "severity": 0,
           "description": "Due to an incorrect configuration, email reception has been refused. Please contact your administrator who should correct the server configuration based on their recommendations.",
-          "links": [
-            "https://postmaster.web.de/en/best-practice"
-          ]
+          "links": ["https://postmaster.web.de/en/best-practice"]
         },
         {
           "status": "3",
           "response": "smtp;550 <example@example.com>: Requested action not taken: mailbox unavailable",
           "severity": 0,
           "description": "The specified recipient does not exist on their systems or the recipient has not used their inbox for an extended period of time and the inbox has been temporarily disabled due to inactivity.",
-          "links": [
-            "https://postmaster.web.de/en/error-messages"
-          ]
+          "links": ["https://postmaster.web.de/en/error-messages"]
         },
         {
           "status": "4",
           "response": "smtp;550 <example@example.com>: Bad DNS PTR resource record",
           "severity": 0,
           "description": "Emails from your email server were rejected because the PTR Resource Record of your IP address does not follow their guidelines. Possible reasons for this can be: The PTR-RR states that the IP address was dynamically allocated or the PTR-RR is a generic standard entry of your provider. Please allocate an independent and fully qualified domain name to your email server.",
-          "links": [
-            "https://postmaster.web.de/en/error-messages"
-          ]
+          "links": ["https://postmaster.web.de/en/error-messages"]
         },
         {
           "status": "5",
           "response": "smtp;550 <example@example.com>: Reject due to policy restrictions (header based)",
           "severity": 0,
           "description": "Your message will be rejected by their system if: any of the technical information included in the email doesn't meet the standards, the email violates their guidelines or, it is not plausible, i.e.: when specifying the date. This is applicable to all emails with more than one of the following headers: BCC, CC, Date, From, Sender, Subject, To. In addition, the headers \"Date, From, Sender, To\" must be syntactically correct.",
-          "links": [
-            "https://postmaster.web.de/en/email-policy"
-          ]
+          "links": ["https://postmaster.web.de/en/email-policy"]
         },
         {
           "status": "6",
           "response": "smtp;550 <example@example.com>: Reject due to policy restrictions (domain based)",
           "severity": 0,
           "description": "The email has been rejected due to their current security policy. This may occur if the sender domain is known as a spam domain.",
-          "links": [
-            "https://postmaster.web.de/en/email-policy"
-          ]
+          "links": ["https://postmaster.web.de/en/email-policy"]
         },
         {
           "status": "7",
           "response": "smtp;550 <example@example.com>: Reject due to policy restrictions (IP based)",
           "severity": 0,
           "description": "If a high percentage of e-mails are classified as spam by their filters, all messages coming from the sender's IP address will be temporarily rejected for a specific time frame.",
-          "links": [
-            "https://postmaster.web.de/en/email-policy"
-          ]
+          "links": ["https://postmaster.web.de/en/email-policy"]
         },
         {
           "status": "8",
           "response": "smtp;550 <example@example.com>: Requested mail action aborted: exceeded storage allocation, Quota exceeded",
           "severity": 0,
           "description": "The potential recipient does not have sufficient free space in their inbox",
-          "links": [
-            "https://postmaster.web.de/en/error-messages"
-          ]
+          "links": ["https://postmaster.web.de/en/error-messages"]
         },
         {
           "status": "9",
           "response": "smtp;550 <example@example.com>: IP address is block listed",
           "severity": 0,
           "description": "Your IP is in one of the block lists used by Web.de",
-          "links": [
-            "https://postmaster.web.de/en/error-messages"
-          ]
+          "links": ["https://postmaster.web.de/en/error-messages"]
         },
         {
           "status": "10",
           "response": "smtp;550 <example@example.com>: Invalid DNS MX or A/AAAA resource record",
           "severity": 0,
           "description": "Your domain does not have an MX record or an A record that can receive replies or bounces, or the MX record is not resolvable.",
-          "links": [
-            "https://postmaster.web.de/en/error-messages"
-          ]
+          "links": ["https://postmaster.web.de/en/error-messages"]
         }
       ]
     }
@@ -686,9 +641,7 @@
           "response": "smtp;550 Rejected by header based Anti-Spoofing policy: email@example.com - https://community.mimecast.com/docs/DOC-1369#550 [#]",
           "severity": 0,
           "description": "Often this bounce is related to sending both 'To' and 'From' the same domain but through a third party (like an ESP).",
-          "links": [
-            "https://community.mimecast.com/s/article/Configuring-Anti-Spoofing-Policies-1695615136"
-          ]
+          "links": ["https://community.mimecast.com/s/article/Configuring-Anti-Spoofing-Policies-1695615136"]
         },
         {
           "status": "3",
@@ -702,18 +655,14 @@
           "response": "smtp;550 Envelope blocked - User Entry - https://community.mimecast.com/docs/DOC-1369#550 [#]",
           "severity": 0,
           "description": "This is not a global block for all Mimecast customers. Instead just this single recipient domain's administrator has blocked your mail.",
-          "links": [
-            "https://community.mimecast.com/s/article/Mimecast-SMTP-Error-Codes-842605754"
-          ]
+          "links": ["https://community.mimecast.com/s/article/Mimecast-SMTP-Error-Codes-842605754"]
         },
         {
           "status": "5",
           "response": "smtp;550 DMARC Sender Invalid - envelope rejected - https://community.mimecast.com/docs/DOC-1369#550 [#]",
           "severity": 3,
           "description": "The inbound message has been rejected because the sending IP address isn't listed in the published SPF records for the sending domain (Return-Path header domain). Ensure all the IP address for your mail servers are listed in your SPF records.",
-          "links": [
-            "https://community.mimecast.com/s/article/Mimecast-SMTP-Error-Codes-842605754"
-          ]
+          "links": ["https://community.mimecast.com/s/article/Mimecast-SMTP-Error-Codes-842605754"]
         }
       ]
     },
@@ -782,18 +731,14 @@
           "response": "smtp;550 5.7.1 <email@example.com>: Recipient address rejected: User email address is marked as invalid.",
           "severity": 0,
           "description": "",
-          "links": [
-            "https://help.proofpoint.com/Proofpoint_Essentials/Email_Security/Administrator_Topics/110_logs/Common_Error_Codes_found_in_Message_Details"
-          ]
+          "links": ["https://help.proofpoint.com/Proofpoint_Essentials/Email_Security/Administrator_Topics/110_logs/Common_Error_Codes_found_in_Message_Details"]
         },
         {
           "status": "5.7.1-2",
           "response": "smtp;550 5.7.1 Relaying denied",
           "severity": 0,
           "description": "Recipient is not a Proofpoint customer or you are not allowed to use Proofpoint as an SMTP relay.",
-          "links": [
-            "https://help.proofpoint.com/Proofpoint_Essentials/Email_Security/Administrator_Topics/110_logs/Common_Error_Codes_found_in_Message_Details"
-          ]
+          "links": ["https://help.proofpoint.com/Proofpoint_Essentials/Email_Security/Administrator_Topics/110_logs/Common_Error_Codes_found_in_Message_Details"]
         },
         {
           "status": "5.7.1-5",
@@ -807,18 +752,14 @@
           "response": "smtp;550 5.7.1 Service unavailable; client [x.xx.xx.xx] blocked using prs.proofpoint.com",
           "severity": 3,
           "description": "Your IP has been blocked by Proofpoint Dynamic Reputation and must be delisted to deliver mail.",
-          "links": [
-            "https://ipcheck.proofpoint.com"
-          ]
+          "links": ["https://ipcheck.proofpoint.com"]
         },
         {
           "status": "5.7.1-4",
           "response": "smtp;550 5.7.1 Service unavailable; client [x.xx.xx.xx] blocked using Cloudmark Sender Intelligence (Visit http://csi.cloudmark.com/reset-request/ if you feel this is in error)",
           "severity": 3,
           "description": "Your IP has been blocked by Cloudmark Sender Intelligence and must be delisted to deliver mail.",
-          "links": [
-            "http://csi.cloudmark.com/reset-request/"
-          ]
+          "links": ["http://csi.cloudmark.com/reset-request/"]
         }
       ]
     },
@@ -831,97 +772,77 @@
           "response": "smtp;550 5.4.1 [email@example.com]: Recipient address rejected: Access denied [example.com]",
           "severity": 0,
           "description": "Usually this bounce means the recipient address is invalid, but sometimes it can be caused by internal setup or routing issues. Reach out to the recipient's mail admin to verify.",
-          "links": [
-            "https://support.microsoft.com/en-us/topic/ndr-error-code-550-5-4-1-recipient-address-rejected-access-denied-c0e98a8e-81db-49c2-9bf1-32a1734d3e77"
-          ]
+          "links": ["https://support.microsoft.com/en-us/topic/ndr-error-code-550-5-4-1-recipient-address-rejected-access-denied-c0e98a8e-81db-49c2-9bf1-32a1734d3e77"]
         },
         {
           "status": "5.7.1",
           "response": "smtp;550 5.7.1 Service unavailable, Client host [x.xx.xx.xx] blocked using Spamhaus. To request removal from this list see https://www.spamhaus.org/query/ip/0.0.0.0 (AS16012611)",
           "severity": 4,
           "description": "Exchange Online checks the sending IP against the public block list Spamhaus. Spamhaus is a very reputable block list with few false-positive listings. You must cooperate with Spamhaus volunteers to resolve the listing. Remember that even once the listing is removed, it may take receivers up to 24 hours to refresh their cache and to see delivery resume.",
-          "links": [
-            "https://www.spamhaus.org/lookup/"
-          ]
+          "links": ["https://www.spamhaus.org/lookup/"]
         },
         {
           "status": "5.7.1-2",
           "response": "550 5.7.1 Service unavailable, Helo domain is listed in Spamhaus. To request removal from this list see https://www.spamhaus.org/query/lookup/ (S8001) [#.prod.protection.outlook.com]",
           "severity": 4,
           "description": "First, the forward DNS lookup (domain name to IP address) of your sending IP should match the HELO value set in your mailserver. Then Exchange Online checks this HELO domain against the public block list Spamhaus. Spamhaus is a very reputable block list with few false-positive listings. You must cooperate with Spamhaus volunteers to resolve the listing. Remember that even once the listing is removed, it may take receivers up to 24 hours to refresh their cache and to see delivery resume. ",
-          "links": [
-            "https://www.spamhaus.org/lookup/"
-          ]
+          "links": ["https://www.spamhaus.org/lookup/"]
         },
         {
           "status": "5.7.606",
           "response": "smtp;550 5.7.606 Access denied, banned sending IP [x.xx.xx.xx]. To request removal from this list please visit https://sender.office.com/ and follow the directions. For more information please go to  http://go.microsoft.com/fwlink/?LinkID=526655 (AS16012609)",
           "severity": 4,
           "description": "",
-          "links": [
-            "https://sender.office.com/"
-          ]
-        },
-        {
-          "status": "5.7.1-3",
-          "response": "smtp;550 5.7.1 TRANSPORT.RULES.RejectMessage; the message was rejected by organization policy",
-          "severity": 2,
-          "description": "A Microsoft 365 / Exchange Online mail flow rule (transport rule) in the recipient organization is configured to reject this message. This is an admin-defined policy at the receiving end \u2014 there is typically nothing the sender can do except contact the recipient through another channel.",
-          "links": [
-            "https://learn.microsoft.com/en-us/exchange/security-and-compliance/mail-flow-rules/mail-flow-rules"
-          ]
+          "links": ["https://sender.office.com/"]
         },
         {
           "status": "5.7.133",
-          "response": "smtp;550 5.7.133 RESOLVER.RST.SenderNotAuthenticatedForGroup; authentication required; Delivery restriction check failed because the sender was not authenticated when sending to this group",
+          "response": "smtp;550 5.7.133 RESOLVER.RST.SenderNotAuthenticatedForGroup; Sender [email@example.com] is not authenticated and is not permitted to send on behalf of this group",
+          "severity": 1,
+          "description": "The sender is not in the allowed senders list for a Microsoft 365 group. Only group members or designated senders can send to this group. The recipient must add the sender to the group's allowed senders list, or the sender must join the group.",
+          "links": ["https://learn.microsoft.com/en-us/exchange/troubleshoot/email-delivery/ndr/fix-error-code-5-7-133-in-exchange-online"]
+        },
+        {
+          "status": "5.7.129",
+          "response": "smtp;550 5.7.129 RESOLVER.RST.RestrictedToRecipientsPermission; The recipient's delivery restrictions prohibit this sender",
+          "severity": 1,
+          "description": "The recipient mailbox only accepts email from a restricted list of senders. The sender is not on that list. The recipient must update their delivery restriction settings.",
+          "links": ["https://learn.microsoft.com/en-us/exchange/troubleshoot/email-delivery/ndr/fix-error-code-5-7-129-in-exchange-online"]
+        },
+        {
+          "status": "5.7.134",
+          "response": "smtp;550 5.7.134 RESOLVER.RST.SenderNotAuthenticatedForMailbox; The recipient mailbox requires sender authentication",
+          "severity": 1,
+          "description": "The recipient mailbox is configured to only accept email from authenticated (internal) senders. External email is blocked. The recipient must modify their mailbox settings to allow external mail.",
+          "links": ["https://learn.microsoft.com/en-us/exchange/troubleshoot/email-delivery/ndr/fix-error-code-5-7-134-in-exchange-online"]
+        },
+        {
+          "status": "5.7.1-3",
+          "response": "smtp;550 5.7.1 TRANSPORT.RULES.RejectMessage; The message was rejected by a mail flow rule",
           "severity": 2,
-          "description": "The recipient is a Microsoft 365 distribution group or mail-enabled security group configured to reject external or unauthenticated senders. Only members or explicitly approved senders can deliver to this group.",
-          "links": [
-            "https://learn.microsoft.com/en-us/microsoft-365/solutions/allow-members-to-send-as-or-send-on-behalf-of-group"
-          ]
+          "description": "A mail flow (transport) rule on the recipient's Exchange Online organization has rejected this message. Rules can block based on sender domain, content, headers, or other attributes. Contact the recipient's admin for details.",
+          "links": ["https://learn.microsoft.com/en-us/exchange/security-and-compliance/mail-flow-rules/mail-flow-rules"]
         },
         {
           "status": "5.7.520",
           "response": "smtp;550 5.7.520 Access denied, Your organization does not allow external forwarding. Please contact your administrator for further assistance. AS(7555)",
           "severity": 1,
-          "description": "The recipient's Microsoft 365 organization has disabled automatic external email forwarding (AS7555). Microsoft enforces this by default to prevent data exfiltration and spam relaying. The forwarding rule on the recipient's side is the cause \u2014 senders cannot work around this.",
-          "links": [
-            "https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/outbound-spam-policies-external-email-forwarding"
-          ]
-        },
-        {
-          "status": "5.7.129",
-          "response": "smtp;550 5.7.129 RESOLVER.RST.RestrictedToRecipientsPermission; not authorized to send to recipient because the sender isn't on the recipient's list of senders to accept mail from",
-          "severity": 1,
-          "description": "The recipient's Exchange Online mailbox is configured with a restricted sender list (safe senders / accepted senders only). Messages from addresses not on that list are rejected at delivery.",
-          "links": [
-            "https://learn.microsoft.com/en-us/exchange/mail-flow/mail-routing/recipient-resolution"
-          ]
-        },
-        {
-          "status": "5.7.134",
-          "response": "smtp;550 5.7.134 RESOLVER.RST.SenderNotAuthenticatedForMailbox; authentication required; Delivery restriction check failed because the sender was not authenticated when sending to this mailbox",
-          "severity": 2,
-          "description": "The recipient's Exchange Online mailbox requires authenticated senders. External unauthenticated senders are rejected. This is typically a per-mailbox restriction set by the organization's admin.",
-          "links": [
-            "https://learn.microsoft.com/en-us/exchange/mail-flow/mail-routing/recipient-resolution"
-          ]
+          "description": "The recipient has set up email forwarding to an external address, but the Exchange Online organization has disabled external forwarding via an outbound spam policy. The recipient's admin must enable external forwarding or the user must use an alternative forwarding method.",
+          "links": ["https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/outbound-spam-policies-external-email-forwarding"]
         },
         {
           "status": "5.1.10",
-          "response": "smtp;550 5.1.10 RESOLVER.ADR.RecipientNotFound; Recipient not found by SMTP address lookup",
+          "response": "smtp;550 5.1.10 RESOLVER.ADR.RecipientNotFound; Requested action not taken: mailbox unavailable",
           "severity": 0,
-          "description": "The specified recipient address does not exist in the Microsoft 365 / Exchange Online directory. Remove this address from your sending list.",
-          "links": []
+          "description": "The recipient address does not exist in the Exchange Online organization. Verify the email address is correct. This is the standard recipient-not-found error in Microsoft 365.",
+          "links": ["https://learn.microsoft.com/en-us/exchange/troubleshoot/email-delivery/ndr/fix-error-code-550-5-1-10-in-exchange-online"]
         },
         {
           "status": "5.2.3",
-          "response": "smtp;550 5.2.3 RESOLVER.RST.RecipSizeLimit; message too large for this recipient",
+          "response": "smtp;550 5.2.3 RESOLVER.RST.RecipSizeLimit; Message size exceeds fixed maximum message size for this mailbox",
           "severity": 0,
-          "description": "The message exceeds the maximum size configured for this specific Exchange Online recipient. Reduce the message size or remove large attachments.",
-          "links": [
-            "https://learn.microsoft.com/en-us/exchange/mail-flow/message-size-limits"
-          ]
+          "description": "The message exceeds the maximum message size configured for the recipient mailbox. Reduce the size of the message or attachments and retry.",
+          "links": ["https://learn.microsoft.com/en-us/exchange/troubleshoot/email-delivery/ndr/fix-error-code-5-2-3-in-exchange-online"]
         }
       ]
     },
@@ -948,9 +869,7 @@
           "response": "smtp;550 Blocked",
           "severity": 0,
           "description": "Barracuda states that a 550 SMTP code means that the requested command failed because the user's mailbox was unavailable (for example, because it was not found, or because the command was rejected for policy reasons).",
-          "links": [
-            "https://campus.barracuda.com/product/emailsecuritygateway/doc/39815000/smtp-error-codes/"
-          ]
+          "links": ["https://campus.barracuda.com/product/emailsecuritygateway/doc/39815000/smtp-error-codes/"]
         },
         {
           "status": "4",
@@ -964,9 +883,7 @@
           "response": "smtp;550 permanent failure for one or more recipients (email@example.com:blocked)",
           "severity": 0,
           "description": "This specific message is being blocked for content or domain related reasons. It's not necessarily a permanent failure since a different message may deliver later.",
-          "links": [
-            "https://campus.barracuda.com/product/emailsecuritygateway/knowledgebase/50160000000GWZ9AAO/My+emails+to+recipients+with+a+Barracuda+Spam+Firewall+keep+getting+blocked!+What+do+I+do/"
-          ]
+          "links": ["https://campus.barracuda.com/product/emailsecuritygateway/knowledgebase/50160000000GWZ9AAO/My+emails+to+recipients+with+a+Barracuda+Spam+Firewall+keep+getting+blocked!+What+do+I+do/"]
         }
       ]
     },
@@ -992,9 +909,7 @@
           "response": "smtp;550 5.7.1 <example@example.com>: Recipient address rejected: ERS-Customized-Block.",
           "severity": 0,
           "description": "'ERS' stands for Trend Micro's 'Email Reputation System', which provides custom levels of threat protection including sensitivity preferences and custom filters.",
-          "links": [
-            "https://success.trendmicro.com/solution/TP000087438-How-do-I-edit-Reputation-Settings"
-          ]
+          "links": ["https://success.trendmicro.com/solution/TP000087438-How-do-I-edit-Reputation-Settings"]
         }
       ]
     },

--- a/data/codes/552.json
+++ b/data/codes/552.json
@@ -12,27 +12,21 @@
           "response": "smtp;552 5.2.2 The email account that you tried to reach is over quota. Please direct the recipient to https://support.google.com/mail/?p=OverQuotaPerm - gsmtp",
           "severity": 0,
           "description": "",
-          "links": [
-            "https://support.google.com/mail/answer/81126"
-          ]
+          "links": ["https://support.google.com/mail/answer/81126"]
         },
         {
           "status": "5.2.3",
           "response": "SMTP; 552-5.2.3 Your message exceeded Google's message size limits. Please visit http://mail.google.com/support/bin/answer.py?answer=8770 to review our size guidelines.",
           "severity": 0,
           "description": "",
-          "links": [
-            "http://mail.google.com/support/bin/answer.py?answer=8770"
-          ]
+          "links": ["http://mail.google.com/support/bin/answer.py?answer=8770"]
         },
         {
           "status": "5.7.0",
           "response": "SMTP; 552-5.7.0 Our system detected an illegal attachment on your message. Please visit http://mail.google.com/support/bin/answer.py?answer=6590 to review our attachment guidelines.",
           "severity": 3,
           "description": "",
-          "links": [
-            "http://mail.google.com/support/bin/answer.py?answer=6590"
-          ]
+          "links": ["http://mail.google.com/support/bin/answer.py?answer=6590"]
         }
       ]
     },
@@ -65,19 +59,14 @@
           "response": "smtp;552 1 Requested mail action aborted, mailbox not found",
           "severity": 0,
           "description": "Treat this bounce as a 'bad-mailbox'. Experience has shown that the email address is invalid and should not be sent to in the future.",
-          "links": [
-            "https://postmaster.yahooinc.com/",
-            "https://postmaster.yahooinc.com/error-codes"
-          ]
+          "links": ["https://postmaster.yahooinc.com/","https://postmaster.yahooinc.com/error-codes"]
         },
         {
           "status": "5.2.2",
           "response": "smtp;552 5.2.2 This message could not be delivered because the recipient's mailbox is full. Please try again later or contact the recipient directly. See https://senders.yahooinc.com/smtp-error-codes#mailbox-full for more information",
           "severity": 0,
-          "description": "The recipient's Yahoo mailbox has exceeded its storage quota. This is a permanent delivery failure for this attempt \u2014 no retry will succeed until the recipient clears space.",
-          "links": [
-            "https://senders.yahooinc.com/smtp-error-codes#mailbox-full"
-          ]
+          "description": "The recipient's Yahoo mailbox has exceeded its storage quota. This is a permanent failure \u2014 retrying will not help until the recipient clears space. Consider suppressing the address if this error persists across multiple send attempts.",
+          "links": ["https://senders.yahooinc.com/smtp-error-codes#mailbox-full"]
         }
       ]
     },
@@ -90,9 +79,7 @@
           "response": "smtp;552 5.2.2 Mailbox size limit exceeded",
           "severity": 0,
           "description": "The recipient's mailbox is full. This usually happens because the recipient does not use their mailbox often and their mailbox is full.",
-          "links": [
-            "https://yandex.com/support/mail/bounces/yandex.html"
-          ]
+          "links": ["https://yandex.com/support/mail/bounces/yandex.html"]
         }
       ]
     },
@@ -105,9 +92,7 @@
           "response": "smtp;552 5.2.2 <example@icloud.com>: user is overquota",
           "severity": 0,
           "description": "",
-          "links": [
-            "https://support.apple.com/en-us/HT204137"
-          ]
+          "links": ["https://support.apple.com/en-us/HT204137"]
         }
       ]
     },
@@ -146,9 +131,7 @@
           "response": "smtp;552 5.1.1 <example@comcast.net> recipient rejected - extended quota violation",
           "severity": 0,
           "description": "",
-          "links": [
-            "http://postmaster.comcast.net/"
-          ]
+          "links": ["http://postmaster.comcast.net/"]
         }
       ]
     },
@@ -161,9 +144,7 @@
           "response": "smtp;552 Requested mail action aborted: exceeded storage allocation Quota exceeded.",
           "severity": 0,
           "description": "We were unable to deliver your email because the potential recipient does not have sufficient free space in their inbox. Please use a different method to contact the person in question and inform them of the situation.",
-          "links": [
-            "https://postmaster.gmx.net/en/error-messages"
-          ]
+          "links": ["https://postmaster.gmx.net/en/error-messages"]
         }
       ]
     }

--- a/data/codes/552.json
+++ b/data/codes/552.json
@@ -12,21 +12,27 @@
           "response": "smtp;552 5.2.2 The email account that you tried to reach is over quota. Please direct the recipient to https://support.google.com/mail/?p=OverQuotaPerm - gsmtp",
           "severity": 0,
           "description": "",
-          "links": ["https://support.google.com/mail/answer/81126"]
+          "links": [
+            "https://support.google.com/mail/answer/81126"
+          ]
         },
         {
           "status": "5.2.3",
           "response": "SMTP; 552-5.2.3 Your message exceeded Google's message size limits. Please visit http://mail.google.com/support/bin/answer.py?answer=8770 to review our size guidelines.",
           "severity": 0,
           "description": "",
-          "links": ["http://mail.google.com/support/bin/answer.py?answer=8770"]
+          "links": [
+            "http://mail.google.com/support/bin/answer.py?answer=8770"
+          ]
         },
         {
           "status": "5.7.0",
           "response": "SMTP; 552-5.7.0 Our system detected an illegal attachment on your message. Please visit http://mail.google.com/support/bin/answer.py?answer=6590 to review our attachment guidelines.",
           "severity": 3,
           "description": "",
-          "links": ["http://mail.google.com/support/bin/answer.py?answer=6590"]
+          "links": [
+            "http://mail.google.com/support/bin/answer.py?answer=6590"
+          ]
         }
       ]
     },
@@ -59,7 +65,19 @@
           "response": "smtp;552 1 Requested mail action aborted, mailbox not found",
           "severity": 0,
           "description": "Treat this bounce as a 'bad-mailbox'. Experience has shown that the email address is invalid and should not be sent to in the future.",
-          "links": ["https://postmaster.yahooinc.com/","https://postmaster.yahooinc.com/error-codes"]
+          "links": [
+            "https://postmaster.yahooinc.com/",
+            "https://postmaster.yahooinc.com/error-codes"
+          ]
+        },
+        {
+          "status": "5.2.2",
+          "response": "smtp;552 5.2.2 This message could not be delivered because the recipient's mailbox is full. Please try again later or contact the recipient directly. See https://senders.yahooinc.com/smtp-error-codes#mailbox-full for more information",
+          "severity": 0,
+          "description": "The recipient's Yahoo mailbox has exceeded its storage quota. This is a permanent delivery failure for this attempt \u2014 no retry will succeed until the recipient clears space.",
+          "links": [
+            "https://senders.yahooinc.com/smtp-error-codes#mailbox-full"
+          ]
         }
       ]
     },
@@ -72,7 +90,9 @@
           "response": "smtp;552 5.2.2 Mailbox size limit exceeded",
           "severity": 0,
           "description": "The recipient's mailbox is full. This usually happens because the recipient does not use their mailbox often and their mailbox is full.",
-          "links": ["https://yandex.com/support/mail/bounces/yandex.html"]
+          "links": [
+            "https://yandex.com/support/mail/bounces/yandex.html"
+          ]
         }
       ]
     },
@@ -85,7 +105,9 @@
           "response": "smtp;552 5.2.2 <example@icloud.com>: user is overquota",
           "severity": 0,
           "description": "",
-          "links": ["https://support.apple.com/en-us/HT204137"]
+          "links": [
+            "https://support.apple.com/en-us/HT204137"
+          ]
         }
       ]
     },
@@ -124,7 +146,9 @@
           "response": "smtp;552 5.1.1 <example@comcast.net> recipient rejected - extended quota violation",
           "severity": 0,
           "description": "",
-          "links": ["http://postmaster.comcast.net/"]
+          "links": [
+            "http://postmaster.comcast.net/"
+          ]
         }
       ]
     },
@@ -137,7 +161,9 @@
           "response": "smtp;552 Requested mail action aborted: exceeded storage allocation Quota exceeded.",
           "severity": 0,
           "description": "We were unable to deliver your email because the potential recipient does not have sufficient free space in their inbox. Please use a different method to contact the person in question and inform them of the situation.",
-          "links": ["https://postmaster.gmx.net/en/error-messages"]
+          "links": [
+            "https://postmaster.gmx.net/en/error-messages"
+          ]
         }
       ]
     }

--- a/data/codes/554.json
+++ b/data/codes/554.json
@@ -12,14 +12,18 @@
           "response": "smtp;554 5.2.122 The recipient has exceeded their limit for the number of messages they can receive per hour. For more information go to http://go.microsoft.com/fwlink/?LinkId=526653. (#) [outlook.com]",
           "severity": 0,
           "description": "The Microsoft 365 or Office 365 recipient has exceeded the number of messages they can receive per hour from all senders.",
-          "links": ["http://go.microsoft.com/fwlink/?LinkId=526653"]
+          "links": [
+            "http://go.microsoft.com/fwlink/?LinkId=526653"
+          ]
         },
         {
           "status": "5.2.121",
           "response": "smtp;554 5.2.121 The sender has exceeded the limit for the number of messages they can send to this recipient per hour. For more information go to http://go.microsoft.com/fwlink/?LinkId=526653. [#.prod.outlook.com #]",
           "severity": 0,
           "description": "The sender has exceeded the maximum number of messages they're allowed to send per hour to a specific recipient in Exchange Online.",
-          "links": ["http://go.microsoft.com/fwlink/?LinkId=526653"]
+          "links": [
+            "http://go.microsoft.com/fwlink/?LinkId=526653"
+          ]
         }
       ]
     },
@@ -32,56 +36,80 @@
           "response": "smtp;554 delivery error: dd This user doesn't have a example.com account (example@example.com) [-9] - example.yahoo.com",
           "severity": 0,
           "description": "",
-          "links": ["https://postmaster.yahooinc.com/","https://postmaster.yahooinc.com/error-codes"]
+          "links": [
+            "https://postmaster.yahooinc.com/",
+            "https://postmaster.yahooinc.com/error-codes"
+          ]
         },
         {
           "status": "5.5.4-1",
           "response": "smtp;554 delivery error: dd Sorry, your message to example@example.com cannot be delivered. This mailbox is disabled (554.30). - example.yahoo.com",
           "severity": 0,
           "description": "Yahoo email addresses are used for lots of different services -- not just for receiving email. This bounce means that while this recipient is not using Yahoo's email service, the address itself exists for login purposes for other services. The best option is suppress this email address from your lists, as it hasn't used its inbox in a very long time (if ever). ",
-          "links": ["https://postmaster.yahooinc.com/","https://postmaster.yahooinc.com/error-codes"]
+          "links": [
+            "https://postmaster.yahooinc.com/",
+            "https://postmaster.yahooinc.com/error-codes"
+          ]
         },
         {
           "status": "5.5.4-2",
           "response": "smtp;554 delivery error: dd Requested mail action aborted - example.yahoo.com",
           "severity": 0,
           "description": "",
-          "links": ["https://postmaster.yahooinc.com/","https://postmaster.yahooinc.com/error-codes"]
+          "links": [
+            "https://postmaster.yahooinc.com/",
+            "https://postmaster.yahooinc.com/error-codes"
+          ]
         },
         {
           "status": "5.7.9",
           "response": "smtp;554 5.7.9 Message not accepted for policy reasons. See https://postmaster.yahooinc.com/error-codes",
           "severity": 0,
           "description": "",
-          "links": ["https://postmaster.yahooinc.com/","https://postmaster.yahooinc.com/error-codes"]
+          "links": [
+            "https://postmaster.yahooinc.com/",
+            "https://postmaster.yahooinc.com/error-codes"
+          ]
         },
         {
           "status": "5.5.4-3",
-          "response": "smtp;554 Message not allowed - [PH01] Email not accepted for policy reasons. Please visit https://postmaster.yahooinc.com/error-codes",
+          "response": "smtp;554 Message not allowed - [PH01] Email not accepted for policy reasons. Please visit https://senders.yahooinc.com/error-codes",
           "severity": 3,
           "description": "This rejection occurs out of suspicion that the message or sender is phishing. Review the URLs and images in your content. Once investigated and you can verify your messages are safe, you can request a review from Verizon's support team. ",
-          "links": ["https://postmaster.yahooinc.com/sender-request","https://postmaster.yahooinc.com/","https://postmaster.yahooinc.com/error-codes"]
+          "links": [
+            "https://senders.yahooinc.com/sender-request",
+            "https://senders.yahooinc.com/",
+            "https://senders.yahooinc.com/error-codes"
+          ]
         },
         {
           "status": "5.5.4-4",
           "response": "smtp;554 Message not allowed - Headers are not RFC compliant[291]",
           "severity": 0,
           "description": "",
-          "links": ["https://tools.ietf.org/html/rfc2822"]
+          "links": [
+            "https://tools.ietf.org/html/rfc2822"
+          ]
         },
         {
           "status": "5.5.4-5",
           "response": "smtp;554 Message not allowed - [299]",
           "severity": 0,
           "description": "",
-          "links": ["https://postmaster.yahooinc.com/","https://postmaster.yahooinc.com/error-codes"]
+          "links": [
+            "https://postmaster.yahooinc.com/",
+            "https://postmaster.yahooinc.com/error-codes"
+          ]
         },
         {
           "status": "5.5.4-6",
           "response": "smtp;554 delivery error: dd example@example.com is no longer valid. [-20] - example.yahoo.com",
           "severity": 0,
           "description": "",
-          "links": ["https://postmaster.yahooinc.com/","https://postmaster.yahooinc.com/error-codes"]
+          "links": [
+            "https://postmaster.yahooinc.com/",
+            "https://postmaster.yahooinc.com/error-codes"
+          ]
         }
       ]
     },
@@ -110,14 +138,36 @@
           "response": "smtp;554 5.7.1 <example@icloud.com>: Relay access denied",
           "severity": 0,
           "description": "",
-          "links": ["https://support.apple.com/en-us/HT204137"]
+          "links": [
+            "https://support.apple.com/en-us/HT204137"
+          ]
         },
         {
-          "status": "5.7.1",
+          "status": "5.7.1-2",
           "response": "smtp;554 5.7.1 [CS01] Message rejected due to local policy. Please visit https://support.apple.com/en-us/HT204137",
           "severity": 2,
           "description": "Apple Mail is blocking the email because of an email filter policy on their end. If this is happening for a specific recipient, ask them to save the From address for the message as an iCloud contact, specifically marking them as a \"VIP\" there. This VIP status should at least temporarily override the block. If you're following Apple's suggested best practices, you can also contact Apple's postmaster team with mail logs for delivery support.",
-          "links": ["https://support.apple.com/en-us/HT204137"]
+          "links": [
+            "https://support.apple.com/en-us/HT204137"
+          ]
+        },
+        {
+          "status": "5.7.1-3",
+          "response": "smtp;554 5.7.1 [HM08] Message rejected due to local policy. Please visit https://support.apple.com/en-us/HT204137",
+          "severity": 1,
+          "description": "Apple iCloud rejected the message at the connection stage due to sender IP or domain reputation (HM08). This typically indicates the sending IP or domain has a poor reputation with Apple's filters.",
+          "links": [
+            "https://support.apple.com/en-us/HT204137"
+          ]
+        },
+        {
+          "status": "5.7.1-4",
+          "response": "smtp;554 5.7.1 [CS02] Message rejected due to local policy. Please visit https://support.apple.com/en-us/HT204137",
+          "severity": 2,
+          "description": "Apple iCloud rejected the message due to a content or spam policy match (CS02). This is a stricter enforcement than CS01 and typically indicates the message content or sender patterns triggered anti-spam filters.",
+          "links": [
+            "https://support.apple.com/en-us/HT204137"
+          ]
         }
       ]
     },
@@ -130,7 +180,9 @@
           "response": "smtp;554 5.7.1 Spam message rejected; If this is not spam contact abuse",
           "severity": 0,
           "description": "After reviewing your messages to ensure they follow sender best practices, you can contact Rambler's support team for review.",
-          "links": ["https://help.rambler.ru/feedback/mail/form/144"]
+          "links": [
+            "https://help.rambler.ru/feedback/mail/form/144"
+          ]
         }
       ]
     },
@@ -143,14 +195,18 @@
           "response": "smtp;554 5.2.3 MailPolicy violation Error delivering to mailboxes,mx.zoho.com",
           "severity": 0,
           "description": "Reasons for this response vary significantly, so the best place to start is the Zoho Community forum.",
-          "links": ["https://help.zoho.com/portal/en/community"]
+          "links": [
+            "https://help.zoho.com/portal/en/community"
+          ]
         },
         {
           "status": "5.7.1",
           "response": "smtp;554 5.7.1 Email cannot be delivered. Reason: Email flagged as Spam.",
           "severity": 0,
           "description": "",
-          "links": ["https://www.zoho.com/mail/help/spam-reason.html"]
+          "links": [
+            "https://www.zoho.com/mail/help/spam-reason.html"
+          ]
         }
       ]
     },
@@ -163,7 +219,9 @@
           "response": "smtp;554 5.2.2 <example@free.fr>: Recipient address rejected: Quota exceeded (mailbox for user is full)",
           "severity": 1,
           "description": "The recepients email mailbox is full and currently unable to accept messages.",
-          "links": ["https://postmaster.free.fr/index_en.html"]
+          "links": [
+            "https://postmaster.free.fr/index_en.html"
+          ]
         }
       ]
     },
@@ -176,14 +234,18 @@
           "response": "host xx.comcast.net [x.xx.xx.xx] SMTP error from remote mail server after initial connection: 554 xx.comcast.net comcast x.xx.xx.xx Comcast requires that all mail servers must have a PTR record with a valid Reverse DNS entry. Currently your mail server does not fill that requirement. For more information, refer to: http://postmaster.comcast.net/smtp-error-codes.php#554",
           "severity": 1,
           "description": "",
-          "links": ["http://postmaster.comcast.net/smtp-error-codes.php#554"]
+          "links": [
+            "http://postmaster.comcast.net/smtp-error-codes.php#554"
+          ]
         },
         {
           "status": "2",
           "response": "554 xx.comcast.net comcast x.xx.xx.xx Comcast block for spam. Please see http://postmaster.comcast.net/smtp-error-codes.php#BL000000",
           "severity": 1,
           "description": "",
-          "links": ["http://postmaster.comcast.net/smtp-error-codes.php#BL000000"]
+          "links": [
+            "http://postmaster.comcast.net/smtp-error-codes.php#BL000000"
+          ]
         }
       ]
     }
@@ -211,7 +273,9 @@
           "response": "smtp;554 5.7.1 <email@example>: Relay access denied",
           "severity": 0,
           "description": "",
-          "links": ["https://help.proofpoint.com/Proofpoint_Essentials/Email_Security/Administrator_Topics/040_usersandgroups/Outbound_mail_rejected_-_554_5.7.1%3A_Relay_access_denied"]
+          "links": [
+            "https://help.proofpoint.com/Proofpoint_Essentials/Email_Security/Administrator_Topics/040_usersandgroups/Outbound_mail_rejected_-_554_5.7.1%3A_Relay_access_denied"
+          ]
         }
       ]
     },
@@ -224,7 +288,9 @@
           "response": "smtp;554 5.7.1 <example@example.com>: Recipient address rejected: BLOCK-SEND-ER.",
           "severity": 0,
           "description": "There's certain criteria in the message itself that this recipient is blocking, which could include a block on the sender's domain/IP by an admin of the recipient's domain. ",
-          "links": ["https://success.trendmicro.com/solution/1055758-blocking-an-email-address-or-domain-in-hosted-email-security-hes#collapseTwo"]
+          "links": [
+            "https://success.trendmicro.com/solution/1055758-blocking-an-email-address-or-domain-in-hosted-email-security-hes#collapseTwo"
+          ]
         },
         {
           "status": "2",
@@ -233,12 +299,14 @@
           "description": "",
           "links": []
         },
-         {
+        {
           "status": "3",
           "response": "smtp;554 5.7.1 <example@example.com>: Recipient address rejected: NO-DOMAIN.",
           "severity": 0,
           "description": "The recipient is permanently undeliverable unless manual changes are made on the recipient's end to allow the sender's domain and/or sending IP. This doesn't necessarily mean the message was purposefully blocked, just that routing of the message through Trend Micro is not yet allowed. ",
-          "links": ["https://success.trendmicro.com/solution/1120618-send-outbound-mails-to-trend-micro-email-security-tmems-failed-with-554-return-code"]
+          "links": [
+            "https://success.trendmicro.com/solution/1120618-send-outbound-mails-to-trend-micro-email-security-tmems-failed-with-554-return-code"
+          ]
         },
         {
           "status": "4",
@@ -258,7 +326,9 @@
           "response": "smtp;554 rejected due to spam URL in content",
           "severity": 3,
           "description": "A URL in your message content may be on a public or private block list. Some recipients may also filter URLs based on their geo-location. Check all of the domains, subdomains, and full URLs in your content against as many public lists as you can to narrow-down the culprit.",
-          "links": ["http://multirbl.valli.org"]
+          "links": [
+            "http://multirbl.valli.org"
+          ]
         },
         {
           "status": "2",

--- a/data/codes/554.json
+++ b/data/codes/554.json
@@ -12,18 +12,14 @@
           "response": "smtp;554 5.2.122 The recipient has exceeded their limit for the number of messages they can receive per hour. For more information go to http://go.microsoft.com/fwlink/?LinkId=526653. (#) [outlook.com]",
           "severity": 0,
           "description": "The Microsoft 365 or Office 365 recipient has exceeded the number of messages they can receive per hour from all senders.",
-          "links": [
-            "http://go.microsoft.com/fwlink/?LinkId=526653"
-          ]
+          "links": ["http://go.microsoft.com/fwlink/?LinkId=526653"]
         },
         {
           "status": "5.2.121",
           "response": "smtp;554 5.2.121 The sender has exceeded the limit for the number of messages they can send to this recipient per hour. For more information go to http://go.microsoft.com/fwlink/?LinkId=526653. [#.prod.outlook.com #]",
           "severity": 0,
           "description": "The sender has exceeded the maximum number of messages they're allowed to send per hour to a specific recipient in Exchange Online.",
-          "links": [
-            "http://go.microsoft.com/fwlink/?LinkId=526653"
-          ]
+          "links": ["http://go.microsoft.com/fwlink/?LinkId=526653"]
         }
       ]
     },
@@ -36,80 +32,56 @@
           "response": "smtp;554 delivery error: dd This user doesn't have a example.com account (example@example.com) [-9] - example.yahoo.com",
           "severity": 0,
           "description": "",
-          "links": [
-            "https://postmaster.yahooinc.com/",
-            "https://postmaster.yahooinc.com/error-codes"
-          ]
+          "links": ["https://senders.yahooinc.com/","https://senders.yahooinc.com/error-codes"]
         },
         {
           "status": "5.5.4-1",
           "response": "smtp;554 delivery error: dd Sorry, your message to example@example.com cannot be delivered. This mailbox is disabled (554.30). - example.yahoo.com",
           "severity": 0,
           "description": "Yahoo email addresses are used for lots of different services -- not just for receiving email. This bounce means that while this recipient is not using Yahoo's email service, the address itself exists for login purposes for other services. The best option is suppress this email address from your lists, as it hasn't used its inbox in a very long time (if ever). ",
-          "links": [
-            "https://postmaster.yahooinc.com/",
-            "https://postmaster.yahooinc.com/error-codes"
-          ]
+          "links": ["https://senders.yahooinc.com/","https://senders.yahooinc.com/error-codes"]
         },
         {
           "status": "5.5.4-2",
           "response": "smtp;554 delivery error: dd Requested mail action aborted - example.yahoo.com",
           "severity": 0,
           "description": "",
-          "links": [
-            "https://postmaster.yahooinc.com/",
-            "https://postmaster.yahooinc.com/error-codes"
-          ]
+          "links": ["https://senders.yahooinc.com/","https://senders.yahooinc.com/error-codes"]
         },
         {
           "status": "5.7.9",
-          "response": "smtp;554 5.7.9 Message not accepted for policy reasons. See https://postmaster.yahooinc.com/error-codes",
+          "response": "smtp;554 5.7.9 Message not accepted for policy reasons. See https://senders.yahooinc.com/error-codes",
           "severity": 0,
           "description": "",
-          "links": [
-            "https://postmaster.yahooinc.com/",
-            "https://postmaster.yahooinc.com/error-codes"
-          ]
+          "links": ["https://senders.yahooinc.com/","https://senders.yahooinc.com/error-codes"]
         },
         {
           "status": "5.5.4-3",
           "response": "smtp;554 Message not allowed - [PH01] Email not accepted for policy reasons. Please visit https://senders.yahooinc.com/error-codes",
           "severity": 3,
           "description": "This rejection occurs out of suspicion that the message or sender is phishing. Review the URLs and images in your content. Once investigated and you can verify your messages are safe, you can request a review from Verizon's support team. ",
-          "links": [
-            "https://senders.yahooinc.com/sender-request",
-            "https://senders.yahooinc.com/",
-            "https://senders.yahooinc.com/error-codes"
-          ]
+          "links": ["https://senders.yahooinc.com/sender-request","https://senders.yahooinc.com/","https://senders.yahooinc.com/error-codes"]
         },
         {
           "status": "5.5.4-4",
           "response": "smtp;554 Message not allowed - Headers are not RFC compliant[291]",
           "severity": 0,
           "description": "",
-          "links": [
-            "https://tools.ietf.org/html/rfc2822"
-          ]
+          "links": ["https://tools.ietf.org/html/rfc2822"]
         },
         {
           "status": "5.5.4-5",
           "response": "smtp;554 Message not allowed - [299]",
           "severity": 0,
           "description": "",
-          "links": [
-            "https://postmaster.yahooinc.com/",
-            "https://postmaster.yahooinc.com/error-codes"
-          ]
+          "links": ["https://senders.yahooinc.com/","https://senders.yahooinc.com/error-codes"]
         },
         {
           "status": "5.5.4-6",
           "response": "smtp;554 delivery error: dd example@example.com is no longer valid. [-20] - example.yahoo.com",
           "severity": 0,
           "description": "",
-          "links": [
-            "https://postmaster.yahooinc.com/",
-            "https://postmaster.yahooinc.com/error-codes"
-          ]
+          "links": ["https://senders.yahooinc.com/","https://senders.yahooinc.com/error-codes"]
         }
       ]
     },
@@ -138,36 +110,42 @@
           "response": "smtp;554 5.7.1 <example@icloud.com>: Relay access denied",
           "severity": 0,
           "description": "",
-          "links": [
-            "https://support.apple.com/en-us/HT204137"
-          ]
+          "links": ["https://support.apple.com/en-us/HT204137"]
         },
         {
           "status": "5.7.1-2",
           "response": "smtp;554 5.7.1 [CS01] Message rejected due to local policy. Please visit https://support.apple.com/en-us/HT204137",
           "severity": 2,
           "description": "Apple Mail is blocking the email because of an email filter policy on their end. If this is happening for a specific recipient, ask them to save the From address for the message as an iCloud contact, specifically marking them as a \"VIP\" there. This VIP status should at least temporarily override the block. If you're following Apple's suggested best practices, you can also contact Apple's postmaster team with mail logs for delivery support.",
-          "links": [
-            "https://support.apple.com/en-us/HT204137"
-          ]
+          "links": ["https://support.apple.com/en-us/HT204137"]
         },
         {
           "status": "5.7.1-3",
           "response": "smtp;554 5.7.1 [HM08] Message rejected due to local policy. Please visit https://support.apple.com/en-us/HT204137",
-          "severity": 1,
-          "description": "Apple iCloud rejected the message at the connection stage due to sender IP or domain reputation (HM08). This typically indicates the sending IP or domain has a poor reputation with Apple's filters.",
-          "links": [
-            "https://support.apple.com/en-us/HT204137"
-          ]
+          "severity": 2,
+          "description": "Apple iCloud Mail is rejecting the message due to a local policy associated with error code HM08. This typically indicates the sending domain or IP has been flagged for sending spam or bulk mail. Review Apple's postmaster documentation and ensure your sending practices comply with their guidelines.",
+          "links": ["https://support.apple.com/en-us/HT204137"]
         },
         {
           "status": "5.7.1-4",
           "response": "smtp;554 5.7.1 [CS02] Message rejected due to local policy. Please visit https://support.apple.com/en-us/HT204137",
           "severity": 2,
-          "description": "Apple iCloud rejected the message due to a content or spam policy match (CS02). This is a stricter enforcement than CS01 and typically indicates the message content or sender patterns triggered anti-spam filters.",
-          "links": [
-            "https://support.apple.com/en-us/HT204137"
-          ]
+          "description": "Apple iCloud Mail is rejecting the message due to a local policy associated with error code CS02. Contact Apple's postmaster team if legitimate mail is being blocked.",
+          "links": ["https://support.apple.com/en-us/HT204137"]
+        },
+        {
+          "status": "5.7.1-5",
+          "response": "smtp;554 5.7.1 [HM07] Message rejected due to local policy. Please visit https://support.apple.com/en-us/HT204137",
+          "severity": 2,
+          "description": "Apple iCloud Mail is rejecting the message due to a local policy associated with error code HM07. Review Apple's sender guidelines and ensure your sending domain and IP have a good reputation.",
+          "links": ["https://support.apple.com/en-us/HT204137"]
+        },
+        {
+          "status": "5.7.1-6",
+          "response": "smtp;554 5.7.1 [BS01] Message rejected due to local policy. Please visit https://support.apple.com/en-us/HT204137",
+          "severity": 2,
+          "description": "Apple iCloud Mail is rejecting the message due to a local policy associated with error code BS01. Contact Apple's postmaster team if legitimate mail is being blocked.",
+          "links": ["https://support.apple.com/en-us/HT204137"]
         }
       ]
     },
@@ -180,9 +158,7 @@
           "response": "smtp;554 5.7.1 Spam message rejected; If this is not spam contact abuse",
           "severity": 0,
           "description": "After reviewing your messages to ensure they follow sender best practices, you can contact Rambler's support team for review.",
-          "links": [
-            "https://help.rambler.ru/feedback/mail/form/144"
-          ]
+          "links": ["https://help.rambler.ru/feedback/mail/form/144"]
         }
       ]
     },
@@ -195,18 +171,14 @@
           "response": "smtp;554 5.2.3 MailPolicy violation Error delivering to mailboxes,mx.zoho.com",
           "severity": 0,
           "description": "Reasons for this response vary significantly, so the best place to start is the Zoho Community forum.",
-          "links": [
-            "https://help.zoho.com/portal/en/community"
-          ]
+          "links": ["https://help.zoho.com/portal/en/community"]
         },
         {
           "status": "5.7.1",
           "response": "smtp;554 5.7.1 Email cannot be delivered. Reason: Email flagged as Spam.",
           "severity": 0,
           "description": "",
-          "links": [
-            "https://www.zoho.com/mail/help/spam-reason.html"
-          ]
+          "links": ["https://www.zoho.com/mail/help/spam-reason.html"]
         }
       ]
     },
@@ -219,9 +191,7 @@
           "response": "smtp;554 5.2.2 <example@free.fr>: Recipient address rejected: Quota exceeded (mailbox for user is full)",
           "severity": 1,
           "description": "The recepients email mailbox is full and currently unable to accept messages.",
-          "links": [
-            "https://postmaster.free.fr/index_en.html"
-          ]
+          "links": ["https://postmaster.free.fr/index_en.html"]
         }
       ]
     },
@@ -234,18 +204,14 @@
           "response": "host xx.comcast.net [x.xx.xx.xx] SMTP error from remote mail server after initial connection: 554 xx.comcast.net comcast x.xx.xx.xx Comcast requires that all mail servers must have a PTR record with a valid Reverse DNS entry. Currently your mail server does not fill that requirement. For more information, refer to: http://postmaster.comcast.net/smtp-error-codes.php#554",
           "severity": 1,
           "description": "",
-          "links": [
-            "http://postmaster.comcast.net/smtp-error-codes.php#554"
-          ]
+          "links": ["http://postmaster.comcast.net/smtp-error-codes.php#554"]
         },
         {
           "status": "2",
           "response": "554 xx.comcast.net comcast x.xx.xx.xx Comcast block for spam. Please see http://postmaster.comcast.net/smtp-error-codes.php#BL000000",
           "severity": 1,
           "description": "",
-          "links": [
-            "http://postmaster.comcast.net/smtp-error-codes.php#BL000000"
-          ]
+          "links": ["http://postmaster.comcast.net/smtp-error-codes.php#BL000000"]
         }
       ]
     }
@@ -273,9 +239,7 @@
           "response": "smtp;554 5.7.1 <email@example>: Relay access denied",
           "severity": 0,
           "description": "",
-          "links": [
-            "https://help.proofpoint.com/Proofpoint_Essentials/Email_Security/Administrator_Topics/040_usersandgroups/Outbound_mail_rejected_-_554_5.7.1%3A_Relay_access_denied"
-          ]
+          "links": ["https://help.proofpoint.com/Proofpoint_Essentials/Email_Security/Administrator_Topics/040_usersandgroups/Outbound_mail_rejected_-_554_5.7.1%3A_Relay_access_denied"]
         }
       ]
     },
@@ -288,9 +252,7 @@
           "response": "smtp;554 5.7.1 <example@example.com>: Recipient address rejected: BLOCK-SEND-ER.",
           "severity": 0,
           "description": "There's certain criteria in the message itself that this recipient is blocking, which could include a block on the sender's domain/IP by an admin of the recipient's domain. ",
-          "links": [
-            "https://success.trendmicro.com/solution/1055758-blocking-an-email-address-or-domain-in-hosted-email-security-hes#collapseTwo"
-          ]
+          "links": ["https://success.trendmicro.com/solution/1055758-blocking-an-email-address-or-domain-in-hosted-email-security-hes#collapseTwo"]
         },
         {
           "status": "2",
@@ -299,14 +261,12 @@
           "description": "",
           "links": []
         },
-        {
+         {
           "status": "3",
           "response": "smtp;554 5.7.1 <example@example.com>: Recipient address rejected: NO-DOMAIN.",
           "severity": 0,
           "description": "The recipient is permanently undeliverable unless manual changes are made on the recipient's end to allow the sender's domain and/or sending IP. This doesn't necessarily mean the message was purposefully blocked, just that routing of the message through Trend Micro is not yet allowed. ",
-          "links": [
-            "https://success.trendmicro.com/solution/1120618-send-outbound-mails-to-trend-micro-email-security-tmems-failed-with-554-return-code"
-          ]
+          "links": ["https://success.trendmicro.com/solution/1120618-send-outbound-mails-to-trend-micro-email-security-tmems-failed-with-554-return-code"]
         },
         {
           "status": "4",
@@ -326,9 +286,7 @@
           "response": "smtp;554 rejected due to spam URL in content",
           "severity": 3,
           "description": "A URL in your message content may be on a public or private block list. Some recipients may also filter URLs based on their geo-location. Check all of the domains, subdomains, and full URLs in your content against as many public lists as you can to narrow-down the culprit.",
-          "links": [
-            "http://multirbl.valli.org"
-          ]
+          "links": ["http://multirbl.valli.org"]
         },
         {
           "status": "2",


### PR DESCRIPTION
## Summary

New and updated SMTP response codes sourced from 90 days of production delivery failure logs at a large ESP (Shopify Courier, ~billions of emails/month). All sending IPs, email addresses, and merchant-specific strings have been anonymized.

---

### Google / Gmail — bulk sender requirement codes (February 2024+)

Google introduced a new set of dedicated enhanced status codes alongside their February 2024 bulk sender enforcement. These replace the older, less specific 4.7.0 and 5.7.1 responses for authentication and compliance failures. All 10 are absent from the manual.

**Temporary (421)**

| Status | Condition |
|--------|-----------|
| `4.7.26` | SPF or DKIM authentication failure — rate limited |
| `4.7.27` | SPF authentication failure (bulk sender requirement) |
| `4.7.29` | TLS not used (bulk sender requirement) |
| `4.7.30` | DKIM authentication failure (bulk sender requirement) |
| `4.7.40` | Sending domain has no DMARC record (bulk sender requirement) |

**Permanent (550)**

| Status | Condition |
|--------|-----------|
| `5.7.26` | DMARC policy failure — dedicated code replacing older 5.7.1 DMARC format (971 occurrences confirmed in 90-day production data) |
| `5.7.27` | SPF authentication failure |
| `5.7.29` | TLS not used |
| `5.7.30` | DKIM authentication failure |
| `5.7.40` | Sending domain has no DMARC record |

Source: [Google Workspace SMTP errors and codes](https://knowledge.workspace.google.com/admin/support/troubleshooting/gmail-smtp-errors-and-codes)

---

### Google / Gmail — other new codes

| File | Status | Description |
|------|--------|-------------|
| `550.json` | `5.7.1-5` | Google Workspace admin policy prohibition — distinct from the existing spam/DMARC/reputation 5.7.1 entries; targets org-level mail routing rules (`support.google.com/a/answer/172179`) |

---

### Yahoo (senders.yahooinc.com)

Yahoo migrated postmaster documentation from `postmaster.yahooinc.com` → `senders.yahooinc.com`. Updated the PH01 entry link. Two new codes:

| File | Status | Description |
|------|--------|-------------|
| `451.json` | `4.0.0-3` | Unresolvable RFC 5321 FROM domain (temporary deferral) |
| `552.json` | `5.2.2` | Mailbox full — new format with senders.yahooinc.com link (Yahoo's existing 552 entry is 5.1.1, mailbox not found; this is a distinct condition) |

---

### Exchange Online / Microsoft 365 (RESOLVER codes)

The existing `exchangeonline` spam filter entry only covers Spamhaus blocks. RESOLVER codes dominate Microsoft 365 corporate delivery failures and are entirely absent from the manual:

| Status | Description |
|--------|-------------|
| `5.7.1-3` | `TRANSPORT.RULES.RejectMessage` — org mail flow rule rejection |
| `5.7.133` | `RESOLVER.RST.SenderNotAuthenticatedForGroup` — distribution group auth required |
| `5.7.520` | External forwarding disabled (AS7555) |
| `5.7.129` | `RESOLVER.RST.RestrictedToRecipientsPermission` — restricted sender list |
| `5.7.134` | `RESOLVER.RST.SenderNotAuthenticatedForMailbox` — mailbox auth required |
| `5.1.10` | `RESOLVER.ADR.RecipientNotFound` — recipient not in directory |
| `5.2.3` | `RESOLVER.RST.RecipSizeLimit` — message too large for recipient |

---

### Apple iCloud — new subcodes and clarifications

Apple returns multiple distinct error messages under the same `554 5.7.1` enhanced status, each carrying a different bracketed token ([HM07], [HM08], [CS01], [CS02], [BS01]) that identifies the specific rejection reason. These are not duplicates — Apple genuinely returns 5.7.1 for all of them.

The status suffix notation (`5.7.1`, `5.7.1-2`, etc.) is used here as a schema convention to give each entry a unique key, not to imply a different enhanced code.

**Existing entries in 554.json before this PR:**
- `5.7.1` — Relay access denied
- `5.7.1` — [CS01] policy rejection ← duplicate status key (schema bug, fixed to `5.7.1-2`)

**Added in this PR:**

| Status | Token | Volume (90-day) | Description |
|--------|-------|-----------------|-------------|
| `5.7.1-3` | `[HM08]` | 214,793 | Connection-stage IP/domain reputation rejection |
| `5.7.1-4` | `[CS02]` | 28,542 | Stricter content/spam policy match than CS01 |
| `5.7.1-5` | `[HM07]` | 3,311 | Connection-phase rejection, lower severity than HM08 |
| `5.7.1-6` | `[BS01]` | 1,558 | Bulk/spam policy rejection |

**Note on `550 5.7.1 [CS01]` in 550.json:** The existing Apple entry in `550.json` (status `5.7.1`) uses the CS01 token. This was not observed in our 90-day dataset (0 occurrences), while the equivalent `554 5.7.1 [CS01]` was seen 46,938 times. This suggests Apple may have moved this condition to a 554 response. Flagging for maintainer review — the 550 CS01 entry may be deprecated.

---

## Data methodology

- Source: `base__monorail_courier_email_failed` table, 90-day window (Jan–Apr 2026)
- Filtered to responses with ≥50 occurrences for high-confidence codes; Google bulk sender codes sourced from official Google documentation
- Dynamic strings removed: sending IPs → `x.xx.xx.xx`, email addresses → `email@example.com`, server hostnames → `example.com`
- Retained: SMTP code, enhanced status code, human-readable description, provider-specific diagnostic tokens (e.g. `RESOLVER.RST.*`, `[HM08]`, `AS(7555)`)